### PR TITLE
Split CI and publish workflows for rate limiter

### DIFF
--- a/.github/workflows/ci-rate-limiter.yaml
+++ b/.github/workflows/ci-rate-limiter.yaml
@@ -1,0 +1,123 @@
+name: CI cpex-rate-limiter
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rate_limiter/**"
+      - ".github/workflows/ci-rate-limiter.yaml"
+  pull_request:
+    paths:
+      - "rate_limiter/**"
+      - ".github/workflows/ci-rate-limiter.yaml"
+      - ".github/workflows/pypi-rate-limiter.yaml"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: rate_limiter
+
+jobs:
+  build-linux:
+    name: Build & Test / ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux-x86_64
+          - runner: ubuntu-24.04-arm
+            platform: linux-aarch64
+          - runner: ubuntu-24.04-s390x
+            platform: linux-s390x
+          - runner: ubuntu-24.04-ppc64le
+            platform: linux-ppc64le
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev python3-venv pipx
+
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install maturin
+        run: pipx install maturin
+
+      - name: Build wheel
+        run: maturin build --release --out dist
+
+      - name: Install wheel and test dependencies
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install dist/*.whl pytest pytest-asyncio
+
+      - name: Run tests
+        run: .venv/bin/pytest tests/ -v
+
+  build-macos:
+    name: Build & Test / macos-arm64
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build wheel
+        run: maturin build --release --out dist
+
+      - name: Install wheel and test dependencies
+        run: |
+          pip install dist/*.whl pytest pytest-asyncio
+
+      - name: Run tests
+        run: pytest tests/ -v
+
+  build-windows:
+    name: Build & Test / windows-x86_64
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Rust toolchain
+        run: |
+          Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+          .\rustup-init.exe -y
+          echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build wheel
+        run: maturin build --release --out dist
+
+      - name: Install wheel and test dependencies
+        run: |
+          pip install (Get-Item dist/*.whl).FullName pytest pytest-asyncio
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/.github/workflows/pypi-rate-limiter.yaml
+++ b/.github/workflows/pypi-rate-limiter.yaml
@@ -1,15 +1,9 @@
-name: Build cpex-rate-limiter wheels
+name: Publish cpex-rate-limiter
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "rate_limiter/**"
-      - ".github/workflows/pypi-rate-limiter.yaml"
-  pull_request:
-    paths:
-      - "rate_limiter/**"
-      - ".github/workflows/pypi-rate-limiter.yaml"
+    tags:
+      - "rate-limiter-v*"
   workflow_dispatch:
 
 permissions:
@@ -73,14 +67,8 @@ jobs:
           path: rate_limiter/dist/*.whl
 
   build-macos:
-    name: Build / ${{ matrix.platform }}
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-latest
-            platform: macos-arm64
+    name: Build / macos-arm64
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -110,7 +98,7 @@ jobs:
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.platform }}
+          name: wheel-macos-arm64
           path: rate_limiter/dist/*.whl
 
   build-windows:
@@ -171,13 +159,13 @@ jobs:
           path: rate_limiter/dist/*.tar.gz
 
   # ---------------------------------------------------------------------------
-  # Publish to Test PyPI (on push / PR)
+  # Publish to Test PyPI (manual dispatch only)
   # ---------------------------------------------------------------------------
   publish-testpypi:
     name: Publish to Test PyPI
     needs: [build-linux, build-macos, build-windows, sdist]
     runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && !startsWith(github.ref, 'refs/tags/rate-limiter-v')
+    if: github.event_name == 'workflow_dispatch'
     environment: testpypi
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Split the single `pypi-rate-limiter.yaml` into two workflows:
  - **`ci-rate-limiter.yaml`**: Build & test on push to main (with path filters) and PRs. No publishing.
  - **`pypi-rate-limiter.yaml`**: Build, test & publish. Triggers on `rate-limiter-v*` tags (→ PyPI) or `workflow_dispatch` (→ Test PyPI).
- Fixes the issue where tag pushes triggered Test PyPI publishing instead of production PyPI

## Test plan
- [ ] Push to main with rate_limiter changes triggers only `ci-rate-limiter`
- [ ] PRs trigger only `ci-rate-limiter`
- [ ] Tag push `rate-limiter-v*` triggers `pypi-rate-limiter` and publishes to PyPI
- [ ] Manual dispatch of `pypi-rate-limiter` publishes to Test PyPI