### PR TITLE
Add Windows ARM64 build and rename package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,31 @@
 
 ## Git
 
-- All commits must be signed.
+- All commits must include a DCO sign-off line. Always use `git commit -s` (or pass `-s` when committing).
+
+## Repository Structure
+
+This is a monorepo of standalone plugin packages for the ContextForge Plugin Extensibility (CPEX) Framework. Each plugin lives in its own top-level directory with independent build configuration.
+
+- Plugins are Rust+Python (PyO3/maturin) or pure Python.
+- Each plugin has its own `pyproject.toml`, `Cargo.toml`, `Makefile`, and `tests/`.
+- Package names follow the pattern `cpex-<plugin-name>` (e.g., `cpex-rate-limiter`).
+- `mcpgateway` is a runtime dependency provided by the host gateway — never declare it in `pyproject.toml`.
+
+## Build & Test
+
+From within a plugin directory (e.g., `rate_limiter/`):
+
+```bash
+uv sync --dev              # Install Python dependencies
+make install               # Build Rust extension and install into venv
+make test-all              # Run Rust + Python tests
+make check-all             # fmt-check + clippy + Rust tests
+```
+
+## Conventions
+
+- Python: 3.11+, type hints, snake_case, Pydantic for config validation.
+- Rust: stable toolchain, `cargo fmt`, `clippy -- -D warnings`.
+- All source files must include Apache-2.0 SPDX license headers.
+- Versions are defined in `Cargo.toml` and pulled dynamically by maturin (`dynamic = ["version"]`).

--- a/rate_limiter/pyproject.toml
+++ b/rate_limiter/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "cpex-rate-limiter-plugin"
+name = "cpex-rate-limiter"
 dynamic = ["version"]
 description = "High-performance rate limiter engine for MCP Gateway"
 authors = [{ name = "ContextForge Contributors" }]


### PR DESCRIPTION
## Summary
- Add cross-compiled Windows ARM64 (`aarch64-pc-windows-msvc`) wheel build to both CI and publish workflows
- No tests for this target (no native ARM64 runner available — cross-compiled only)
- Rename PyPI package from `cpex-rate-limiter-plugin` to `cpex-rate-limiter`

## Test plan
- [ ] CI workflow builds Windows ARM64 wheel without errors
- [ ] Publish workflow includes Windows ARM64 artifact alongside other platforms
- [ ] `pip install cpex-rate-limiter` works after next publish