### PR TITLE
Export RateLimiterPlugin from package __init__

### DIFF
--- a/rate_limiter/cpex_rate_limiter/__init__.py
+++ b/rate_limiter/cpex_rate_limiter/__init__.py
@@ -9,3 +9,7 @@ Provides a Rust-backed rate limiter plugin that supports multiple algorithms
 and backends, including in-memory and Redis, for per-user, per-tenant, and/or
 per-tool rate limiting. See the plugin documentation for configuration details.
 """
+
+from cpex_rate_limiter.rate_limiter import RateLimiterPlugin
+
+__all__ = ["RateLimiterPlugin"]


### PR DESCRIPTION
## Summary
- Re-export `RateLimiterPlugin` in `cpex_rate_limiter/__init__.py`
- Fixes `AttributeError: module 'cpex_rate_limiter' has no attribute 'RateLimiterPlugin'`

## Test plan
- [ ] `from cpex_rate_limiter import RateLimiterPlugin` works