### PR TITLE
Bump rate limiter to v0.0.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,13 @@ make check-all             # fmt-check + clippy + Rust tests
 - Rust: stable toolchain, `cargo fmt`, `clippy -- -D warnings`.
 - All source files must include Apache-2.0 SPDX license headers.
 - Versions are defined in `Cargo.toml` and pulled dynamically by maturin (`dynamic = ["version"]`).
+
+## Versioning
+
+When bumping a plugin version, update all of these:
+
+1. `Cargo.toml` — the single source of truth for the version number.
+2. `cpex_<plugin>/plugin-manifest.yaml` — the `version` field.
+3. `Cargo.lock` — updates automatically on the next build.
+
+Tag releases as `<plugin>-v<version>` (e.g., `rate-limiter-v0.0.2`) on `main` to trigger the PyPI publish workflow.

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rate_limiter"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["ContextForge Contributors"]
 license = "Apache-2.0"

--- a/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Team"
-version: "0.0.1"
+version: "0.0.2"
 available_hooks:
   - "prompt_pre_fetch"
   - "tool_pre_invoke"


### PR DESCRIPTION
## Summary
- Bump rate limiter version from 0.0.1 to 0.0.2 in Cargo.toml and plugin-manifest.yaml
- Add versioning section to CLAUDE.md documenting the version bump process

## Test plan
- [ ] CI passes
- [ ] After merge, tag `rate-limiter-v0.0.2` on main to publish to PyPI