### PR TITLE
Add root pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: trailing-whitespace


### PR DESCRIPTION
## Summary
- add a minimal root `.pre-commit-config.yaml`
- stop requiring `PRE_COMMIT_ALLOW_NO_CONFIG=1` for normal commits in this repo
- keep commit-time checks lightweight by using only generic `pre-commit-hooks`

## Verification
- `uvx pre-commit validate-config`
- `uvx pre-commit run --files .pre-commit-config.yaml`
- `env -u PRE_COMMIT_ALLOW_NO_CONFIG /Users/luca/.git-hooks/pre-commit`