### PR TITLE
Fix managed plugin release workflow on partner runners

### DIFF
--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -91,8 +91,22 @@ jobs:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
+
+      - name: Install system Python on partner runners
+        if: ${{ matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
+          python_bin_dir="${RUNNER_TEMP}/python-bin"
+          mkdir -p "${python_bin_dir}"
+          ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"
+          echo "${python_bin_dir}" >> "$GITHUB_PATH"
+          python --version
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
 
       - name: Verify Rust toolchain
         run: |

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -132,14 +132,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
           python_bin_dir="${RUNNER_TEMP}/python-bin"
           mkdir -p "${python_bin_dir}"
-          ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"
+          ln -sf "$(which python3.12)" "${python_bin_dir}/python"
           export PATH="${python_bin_dir}:$PATH"
           echo "${python_bin_dir}" >> "$GITHUB_PATH"
           python --version
           python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
 
       - name: Verify Rust toolchain
         run: |

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -135,6 +135,7 @@ jobs:
           python_bin_dir="${RUNNER_TEMP}/python-bin"
           mkdir -p "${python_bin_dir}"
           ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"
+          export PATH="${python_bin_dir}:$PATH"
           echo "${python_bin_dir}" >> "$GITHUB_PATH"
           python --version
           python -m ensurepip --upgrade

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -91,22 +91,8 @@ jobs:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
-        if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
-
-      - name: Install system Python on partner runners
-        if: ${{ matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
-          python_bin_dir="${RUNNER_TEMP}/python-bin"
-          mkdir -p "${python_bin_dir}"
-          ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"
-          echo "${python_bin_dir}" >> "$GITHUB_PATH"
-          python --version
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
 
       - name: Verify Rust toolchain
         run: |
@@ -137,8 +123,22 @@ jobs:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
+
+      - name: Install system Python on partner runners
+        if: ${{ matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
+          python_bin_dir="${RUNNER_TEMP}/python-bin"
+          mkdir -p "${python_bin_dir}"
+          ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"
+          echo "${python_bin_dir}" >> "$GITHUB_PATH"
+          python --version
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
 
       - name: Verify Rust toolchain
         run: |

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -830,7 +830,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("matrix:\n        include: ${{ fromJson(needs.resolve.outputs.wheel_matrix) }}", workflow)
         self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
         self.assertIn("name: wheel-${{ matrix.platform }}", workflow)
-        self.assertNotIn("matrix.runner", preflight_section)
+        self.assertNotIn("matrix.", preflight_section)
         self.assertIn(
             "matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le'",
             build_wheel_section,
@@ -847,6 +847,7 @@ class PluginCatalogTests(unittest.TestCase):
             'ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"',
             build_wheel_section,
         )
+        self.assertIn('export PATH="${python_bin_dir}:$PATH"', build_wheel_section)
         self.assertIn('python -m ensurepip --upgrade', build_wheel_section)
         self.assertNotIn("tools/plugin_catalog.py release-info-field", workflow)
         self.assertNotIn("python3 - <<'PY'", workflow)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -24,6 +24,30 @@ def run_catalog(*args: str, cwd: Path | None = None) -> subprocess.CompletedProc
 
 
 class PluginCatalogTests(unittest.TestCase):
+    def _extract_workflow_job_section(self, workflow: str, job_name: str) -> str:
+        lines = workflow.splitlines()
+        in_jobs = False
+        job_header = f"  {job_name}:"
+        section_lines: list[str] = []
+
+        for line in lines:
+            if line == "jobs:":
+                in_jobs = True
+                continue
+            if not in_jobs:
+                continue
+            if line.startswith("  ") and not line.startswith("    "):
+                if section_lines:
+                    break
+                if line == job_header:
+                    section_lines.append(line)
+                continue
+            if section_lines:
+                section_lines.append(line)
+
+        self.assertTrue(section_lines, f"expected to find workflow job {job_name!r}")
+        return "\n".join(section_lines) + "\n"
+
     def _source_tree_has_extension(self, package_dir: Path, module_name: str) -> bool:
         return any(package_dir.glob(f"{module_name}*.so")) or any(
             package_dir.glob(f"{module_name}*.pyd")
@@ -804,12 +828,8 @@ class PluginCatalogTests(unittest.TestCase):
         workflow = (
             REPO_ROOT / ".github" / "workflows" / "release-rust-python-package.yaml"
         ).read_text()
-        preflight_section = workflow.split("  preflight:\n", maxsplit=1)[1].split(
-            "  build-wheel:\n", maxsplit=1
-        )[0]
-        build_wheel_section = workflow.split("  build-wheel:\n", maxsplit=1)[1].split(
-            "  build-sdist:\n", maxsplit=1
-        )[0]
+        preflight_section = self._extract_workflow_job_section(workflow, "preflight")
+        build_wheel_section = self._extract_workflow_job_section(workflow, "build-wheel")
         self.assertIn("preflight:", workflow)
         self.assertIn("needs: [resolve, preflight]", workflow)
         self.assertIn("shell: bash", workflow)
@@ -844,11 +864,14 @@ class PluginCatalogTests(unittest.TestCase):
             build_wheel_section,
         )
         self.assertIn(
-            'ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"',
+            'ln -sf "$(which python3.12)" "${python_bin_dir}/python"',
             build_wheel_section,
         )
+        self.assertIn("sudo apt-get clean", build_wheel_section)
+        self.assertIn("sudo rm -rf /var/lib/apt/lists/*", build_wheel_section)
         self.assertIn('export PATH="${python_bin_dir}:$PATH"', build_wheel_section)
         self.assertIn('python -m ensurepip --upgrade', build_wheel_section)
+        self.assertNotIn("python -m pip install --upgrade pip", build_wheel_section)
         self.assertNotIn("tools/plugin_catalog.py release-info-field", workflow)
         self.assertNotIn("python3 - <<'PY'", workflow)
         self.assertIn("uv==0.9.30", workflow)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -804,6 +804,12 @@ class PluginCatalogTests(unittest.TestCase):
         workflow = (
             REPO_ROOT / ".github" / "workflows" / "release-rust-python-package.yaml"
         ).read_text()
+        preflight_section = workflow.split("  preflight:\n", maxsplit=1)[1].split(
+            "  build-wheel:\n", maxsplit=1
+        )[0]
+        build_wheel_section = workflow.split("  build-wheel:\n", maxsplit=1)[1].split(
+            "  build-sdist:\n", maxsplit=1
+        )[0]
         self.assertIn("preflight:", workflow)
         self.assertIn("needs: [resolve, preflight]", workflow)
         self.assertIn("shell: bash", workflow)
@@ -824,17 +830,24 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("matrix:\n        include: ${{ fromJson(needs.resolve.outputs.wheel_matrix) }}", workflow)
         self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
         self.assertIn("name: wheel-${{ matrix.platform }}", workflow)
+        self.assertNotIn("matrix.runner", preflight_section)
         self.assertIn(
             "matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le'",
-            workflow,
+            build_wheel_section,
         )
         self.assertIn(
             "matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le'",
-            workflow,
+            build_wheel_section,
         )
-        self.assertIn("sudo apt-get install -y python3.12 python3.12-dev python3.12-venv", workflow)
-        self.assertIn('ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"', workflow)
-        self.assertIn('python -m ensurepip --upgrade', workflow)
+        self.assertIn(
+            "sudo apt-get install -y python3.12 python3.12-dev python3.12-venv",
+            build_wheel_section,
+        )
+        self.assertIn(
+            'ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"',
+            build_wheel_section,
+        )
+        self.assertIn('python -m ensurepip --upgrade', build_wheel_section)
         self.assertNotIn("tools/plugin_catalog.py release-info-field", workflow)
         self.assertNotIn("python3 - <<'PY'", workflow)
         self.assertIn("uv==0.9.30", workflow)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -489,6 +489,23 @@ class PluginCatalogTests(unittest.TestCase):
             ],
         )
 
+    def test_release_info_gives_pii_filter_the_same_target_matrix(self) -> None:
+        result = run_catalog("release-info", str(REPO_ROOT), "pii-filter-v0.2.0")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["slug"], "pii_filter")
+        self.assertEqual(
+            payload["release_wheel_matrix"],
+            [
+                {"runner": "ubuntu-latest", "platform": "linux-x86_64"},
+                {"runner": "ubuntu-24.04-arm", "platform": "linux-aarch64"},
+                {"runner": "ubuntu-24.04-s390x", "platform": "linux-s390x"},
+                {"runner": "ubuntu-24.04-ppc64le", "platform": "linux-ppc64le"},
+                {"runner": "macos-latest", "platform": "macos-arm64"},
+                {"runner": "windows-latest", "platform": "windows-x86_64"},
+            ],
+        )
+
     def test_release_info_rejects_noncanonical_tag(self) -> None:
         result = run_catalog("release-info", str(REPO_ROOT), "rate_limiter-v0.0.3")
         self.assertNotEqual(result.returncode, 0)
@@ -807,6 +824,17 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("matrix:\n        include: ${{ fromJson(needs.resolve.outputs.wheel_matrix) }}", workflow)
         self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
         self.assertIn("name: wheel-${{ matrix.platform }}", workflow)
+        self.assertIn(
+            "matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le'",
+            workflow,
+        )
+        self.assertIn(
+            "matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le'",
+            workflow,
+        )
+        self.assertIn("sudo apt-get install -y python3.12 python3.12-dev python3.12-venv", workflow)
+        self.assertIn('ln -sf /usr/bin/python3.12 "${python_bin_dir}/python"', workflow)
+        self.assertIn('python -m ensurepip --upgrade', workflow)
         self.assertNotIn("tools/plugin_catalog.py release-info-field", workflow)
         self.assertNotIn("python3 - <<'PY'", workflow)
         self.assertIn("uv==0.9.30", workflow)

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -42,7 +42,7 @@ class PluginRecord:
     release_wheel_matrix: list[dict[str, str]]
 
 
-def _release_wheel_matrix(slug: str) -> list[dict[str, str]]:
+def _release_wheel_matrix() -> list[dict[str, str]]:
     return [
         {"runner": "ubuntu-latest", "platform": "linux-x86_64"},
         {"runner": "ubuntu-24.04-arm", "platform": "linux-aarch64"},
@@ -236,7 +236,7 @@ def validate_plugin_dir(
         package_name=expected_package_name,
         module_name=expected_module_name,
         version=version,
-        release_wheel_matrix=_release_wheel_matrix(slug),
+        release_wheel_matrix=_release_wheel_matrix(),
     )
 
 

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -43,18 +43,11 @@ class PluginRecord:
 
 
 def _release_wheel_matrix(slug: str) -> list[dict[str, str]]:
-    if slug == "rate_limiter":
-        return [
-            {"runner": "ubuntu-latest", "platform": "linux-x86_64"},
-            {"runner": "ubuntu-24.04-arm", "platform": "linux-aarch64"},
-            {"runner": "ubuntu-24.04-s390x", "platform": "linux-s390x"},
-            {"runner": "ubuntu-24.04-ppc64le", "platform": "linux-ppc64le"},
-            {"runner": "macos-latest", "platform": "macos-arm64"},
-            {"runner": "windows-latest", "platform": "windows-x86_64"},
-        ]
-
     return [
         {"runner": "ubuntu-latest", "platform": "linux-x86_64"},
+        {"runner": "ubuntu-24.04-arm", "platform": "linux-aarch64"},
+        {"runner": "ubuntu-24.04-s390x", "platform": "linux-s390x"},
+        {"runner": "ubuntu-24.04-ppc64le", "platform": "linux-ppc64le"},
         {"runner": "macos-latest", "platform": "macos-arm64"},
         {"runner": "windows-latest", "platform": "windows-x86_64"},
     ]


### PR DESCRIPTION
## Summary
- keep the full six-target release matrix for all managed plugins, including `linux-s390x` and `linux-ppc64le`
- bootstrap Python 3.12 on partner runners inside the matrixed `build-wheel` job instead of relying on `actions/setup-python`
- add regression coverage that locks `pii_filter` to the same target matrix and prevents matrix-scoped workflow logic from leaking into `preflight`

## Why
`rate-limiter-v0.0.3` failed because the new monorepo release workflow used `actions/setup-python` on `ubuntu-24.04-s390x` and `ubuntu-24.04-ppc64le`, where that action has no matching Python 3.12 manifest entry. The old successful `rate-limiter` publish workflow used system Python on those runners.

## Verification
- `python3 -m unittest tests.test_plugin_catalog.PluginCatalogTests.test_release_info_accepts_canonical_tag tests.test_plugin_catalog.PluginCatalogTests.test_release_info_gives_pii_filter_the_same_target_matrix tests.test_plugin_catalog.PluginCatalogTests.test_release_workflow_tests_artifacts_outside_source_tree`
- `python3 tools/plugin_catalog.py validate .`
- `python3 -m unittest tests.test_plugin_catalog tests.test_install_built_wheel`

## Review
Ran the standard detailed code review workflow in this task and addressed the actionable findings before opening this PR.
