### PR TITLE
Fix partner-runner Python bootstrap for releases

### DIFF
--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -113,3 +113,12 @@ jobs:
       - name: Plugin CI verification
         working-directory: plugins/rust/python-package/${{ matrix.plugin }}
         run: make ci
+
+  release-validation:
+    if: github.event_name == 'pull_request'
+    needs: validate-and-detect
+    uses: ./.github/workflows/release-rust-python-package.yaml
+    with:
+      tag: rate-limiter-v0.0.3
+      repository: testpypi
+      publish_enabled: false

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -131,7 +131,7 @@ jobs:
         if: ${{ matrix.runner == 'ubuntu-24.04-s390x' || matrix.runner == 'ubuntu-24.04-ppc64le' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3.12 python3.12-dev python3.12-venv
+          sudo apt-get install -y python3.12 python3.12-dev python3.12-venv python3-pip
           sudo apt-get clean
           sudo rm -rf /var/lib/apt/lists/*
           python_bin_dir="${RUNNER_TEMP}/python-bin"
@@ -140,7 +140,7 @@ jobs:
           export PATH="${python_bin_dir}:$PATH"
           echo "${python_bin_dir}" >> "$GITHUB_PATH"
           python --version
-          python -m ensurepip --upgrade
+          python -m pip --version
 
       - name: Verify Rust toolchain
         run: |

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -65,7 +65,11 @@ jobs:
           release_info="$(python3 tools/plugin_catalog.py release-info . "${tag}")"
           plugin="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.load(sys.stdin)["slug"])')"
           plugin_path="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.load(sys.stdin)["path"])')"
-          wheel_matrix="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.dumps(json.load(sys.stdin)["release_wheel_matrix"]))')"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            wheel_matrix="$(python3 -c 'import json; print(json.dumps([{"runner":"ubuntu-latest","platform":"linux-x86_64"},{"runner":"ubuntu-24.04-arm","platform":"linux-aarch64"},{"runner":"ubuntu-24.04-s390x","platform":"linux-s390x"},{"runner":"ubuntu-24.04-ppc64le","platform":"linux-ppc64le"},{"runner":"macos-latest","platform":"macos-arm64"},{"runner":"windows-latest","platform":"windows-x86_64"}]))')"
+          else
+            wheel_matrix="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.dumps(json.load(sys.stdin)["release_wheel_matrix"]))')"
+          fi
 
           {
             echo "plugin=${plugin}"

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -4,6 +4,21 @@ on:
   push:
     tags:
       - "*-v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag in the form <slug>-v<version>"
+        required: true
+        type: string
+      repository:
+        description: "Target package repository"
+        required: true
+        type: string
+      publish_enabled:
+        description: "Whether to run the publish job"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       tag:
@@ -33,8 +48,6 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
@@ -50,7 +63,7 @@ jobs:
           REPOSITORY_INPUT: ${{ inputs.repository }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
             tag="${TAG_INPUT}"
             repository="${REPOSITORY_INPUT}"
             git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
@@ -65,7 +78,7 @@ jobs:
           release_info="$(python3 tools/plugin_catalog.py release-info . "${tag}")"
           plugin="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.load(sys.stdin)["slug"])')"
           plugin_path="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.load(sys.stdin)["path"])')"
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
             wheel_matrix="$(python3 -c 'import json; print(json.dumps([{"runner":"ubuntu-latest","platform":"linux-x86_64"},{"runner":"ubuntu-24.04-arm","platform":"linux-aarch64"},{"runner":"ubuntu-24.04-s390x","platform":"linux-s390x"},{"runner":"ubuntu-24.04-ppc64le","platform":"linux-ppc64le"},{"runner":"macos-latest","platform":"macos-arm64"},{"runner":"windows-latest","platform":"windows-x86_64"}]))')"
           else
             wheel_matrix="$(printf '%s' "${release_info}" | python3 -c 'import json, sys; print(json.dumps(json.load(sys.stdin)["release_wheel_matrix"]))')"
@@ -227,6 +240,7 @@ jobs:
             "${tmpdir}/tests" -v
 
   publish:
+    if: ${{ github.event_name != 'workflow_call' || inputs.publish_enabled }}
     needs: [resolve, build-wheel, build-sdist]
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve.outputs.publish_env }}

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -800,6 +800,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("shell: bash", workflow)
         self.assertIn("rustc --version", workflow)
         self.assertIn("working-directory: plugins/rust/python-package/${{ matrix.plugin }}", workflow)
+        self.assertIn("release-validation:", workflow)
+        self.assertIn("uses: ./.github/workflows/release-rust-python-package.yaml", workflow)
+        self.assertIn("tag: rate-limiter-v0.0.3", workflow)
+        self.assertIn("repository: testpypi", workflow)
+        self.assertIn("publish_enabled: false", workflow)
         self.assertNotIn("tools/plugin_catalog.py ci-selection-field", workflow)
         self.assertNotIn("tools/plugin_catalog.py changed", workflow)
         self.assertNotIn("tools/plugin_catalog.py list", workflow)
@@ -842,7 +847,13 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertEqual(workflow.count("cargo run --bin stub_gen"), 1)
         self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)
         self.assertIn("python3 tools/plugin_catalog.py release-info .", workflow)
-        self.assertIn('if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then', workflow)
+        self.assertIn(
+            'if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" || "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then',
+            workflow,
+        )
+        self.assertIn("workflow_call:", workflow)
+        self.assertIn("publish_enabled:", workflow)
+        self.assertIn('default: false', workflow)
         self.assertIn(
             'wheel_matrix="$(python3 -c \'import json; print(json.dumps([{',
             workflow,
@@ -863,6 +874,10 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("matrix:\n        include: ${{ fromJson(needs.resolve.outputs.wheel_matrix) }}", workflow)
         self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
         self.assertIn("name: wheel-${{ matrix.platform }}", workflow)
+        self.assertIn(
+            "if: ${{ github.event_name != 'workflow_call' || inputs.publish_enabled }}",
+            workflow,
+        )
         self.assertNotIn("matrix.", preflight_section)
         self.assertIn(
             "matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le'",

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -842,6 +842,19 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertEqual(workflow.count("cargo run --bin stub_gen"), 1)
         self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)
         self.assertIn("python3 tools/plugin_catalog.py release-info .", workflow)
+        self.assertIn('if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then', workflow)
+        self.assertIn(
+            'wheel_matrix="$(python3 -c \'import json; print(json.dumps([{',
+            workflow,
+        )
+        self.assertIn(
+            '{"runner":"ubuntu-24.04-s390x","platform":"linux-s390x"}',
+            workflow,
+        )
+        self.assertIn(
+            '{"runner":"ubuntu-24.04-ppc64le","platform":"linux-ppc64le"}',
+            workflow,
+        )
         self.assertIn(
             'wheel_matrix="$(printf \'%s\' "${release_info}" | python3 -c \'import json, sys; print(json.dumps(json.load(sys.stdin)["release_wheel_matrix"]))\')"',
             workflow,

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -860,7 +860,7 @@ class PluginCatalogTests(unittest.TestCase):
             build_wheel_section,
         )
         self.assertIn(
-            "sudo apt-get install -y python3.12 python3.12-dev python3.12-venv",
+            "sudo apt-get install -y python3.12 python3.12-dev python3.12-venv python3-pip",
             build_wheel_section,
         )
         self.assertIn(
@@ -870,7 +870,8 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("sudo apt-get clean", build_wheel_section)
         self.assertIn("sudo rm -rf /var/lib/apt/lists/*", build_wheel_section)
         self.assertIn('export PATH="${python_bin_dir}:$PATH"', build_wheel_section)
-        self.assertIn('python -m ensurepip --upgrade', build_wheel_section)
+        self.assertNotIn('python -m ensurepip --upgrade', build_wheel_section)
+        self.assertIn('python -m pip --version', build_wheel_section)
         self.assertNotIn("python -m pip install --upgrade pip", build_wheel_section)
         self.assertNotIn("tools/plugin_catalog.py release-info-field", workflow)
         self.assertNotIn("python3 - <<'PY'", workflow)


### PR DESCRIPTION
## Summary
- install `python3-pip` for partner runners instead of relying on `ensurepip`
- force manual tag republishes to use the full six-target wheel matrix from the current workflow logic
- run release validation on pull requests by calling the release workflow in non-publishing mode
- update the workflow regression tests to lock the PR validation and partner-runner bootstrap behavior

## Why
The manual rerun for `rate-limiter-v0.0.3` still failed on `ubuntu-24.04-s390x` and `ubuntu-24.04-ppc64le` because Ubuntu disables `ensurepip` for the system Python package. There was also no PR-time release validation path, so release-only failures were escaping until tags were already cut. This change fixes the bootstrap path and makes PR CI exercise the release workflow without publishing.

## Validation
Local:
- `python3 -m unittest tests.test_plugin_catalog.PluginCatalogTests.test_ci_workflow_uses_make_targets_for_plugin_checks tests.test_plugin_catalog.PluginCatalogTests.test_release_workflow_tests_artifacts_outside_source_tree`
- `python3 tools/plugin_catalog.py validate .`
- `python3 -m unittest tests.test_plugin_catalog tests.test_install_built_wheel`

Workflow validation:
- Triggered `release-rust-python-package.yaml` from this PR branch for `rate-limiter-v0.0.3` against `testpypi`: https://github.com/IBM/cpex-plugins/actions/runs/23951099380
- All six wheel builds and tests passed, including `linux-s390x` and `linux-ppc64le`
- Final `Publish distributions to TestPyPI` step failed after artifact assembly; the workflow logic and matrix/bootstrap path completed successfully before that publish step

## Review
Please run the standard `detailed-code-review` workflow for this PR before merge.