### PR TITLE
Add explicit plugin kind metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Each plugin lives in its own top-level directory (e.g., `rate_limiter/`). New pl
 - A `pyproject.toml` with maturin as the build backend (for Rust+Python plugins) or setuptools (for pure Python plugins).
 - A `Makefile` with standard targets: `build`, `install`, `test`, `test-python`, `test-all`, `fmt`, `clippy`, `check-all`, `clean`.
 - A `README.md` documenting configuration, usage, and limitations.
-- A `plugin-manifest.yaml` inside the Python package directory with an explicit `kind`.
+- A `plugin-manifest.yaml` inside the Python package directory with an explicit `kind` in `module:object` form.
 - A matching plugin entry point in `pyproject.toml` under `[project.entry-points."cpex.plugins"]`.
 - A `tests/` directory with pytest tests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ Each plugin lives in its own top-level directory (e.g., `rate_limiter/`). New pl
 - A `pyproject.toml` with maturin as the build backend (for Rust+Python plugins) or setuptools (for pure Python plugins).
 - A `Makefile` with standard targets: `build`, `install`, `test`, `test-python`, `test-all`, `fmt`, `clippy`, `check-all`, `clean`.
 - A `README.md` documenting configuration, usage, and limitations.
-- A `plugin-manifest.yaml` inside the Python package directory with an explicit `kind` in `module:object` form.
-- A matching plugin entry point in `pyproject.toml` under `[project.entry-points."cpex.plugins"]`.
+- A `plugin-manifest.yaml` inside the Python package directory with an explicit `kind` in `module.object` form.
+- A matching plugin entry point in `pyproject.toml` under `[project.entry-points."cpex.plugins"]` in `module:object` form.
 - A `tests/` directory with pytest tests.
 
 ### Merge Approval

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ Each plugin lives in its own top-level directory (e.g., `rate_limiter/`). New pl
 - A `pyproject.toml` with maturin as the build backend (for Rust+Python plugins) or setuptools (for pure Python plugins).
 - A `Makefile` with standard targets: `build`, `install`, `test`, `test-python`, `test-all`, `fmt`, `clippy`, `check-all`, `clean`.
 - A `README.md` documenting configuration, usage, and limitations.
-- A `plugin-manifest.yaml` inside the Python package directory.
+- A `plugin-manifest.yaml` inside the Python package directory with an explicit `kind`.
+- A matching plugin entry point in `pyproject.toml` under `[project.entry-points."cpex.plugins"]`.
 - A `tests/` directory with pytest tests.
 
 ### Merge Approval

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,8 +16,8 @@ Every managed plugin must satisfy the catalog contract enforced by `tools/plugin
 - Python module: `cpex_<slug>`
 - `Cargo.toml` is the version source of truth
 - `cpex_<slug>/plugin-manifest.yaml` version matches `Cargo.toml`
-- `cpex_<slug>/plugin-manifest.yaml` defines top-level `kind`
-- `pyproject.toml` publishes the same plugin class under `[project.entry-points."cpex.plugins"]`
+- `cpex_<slug>/plugin-manifest.yaml` defines top-level `kind` in `module:object` form
+- `pyproject.toml` publishes the same plugin class reference under `[project.entry-points."cpex.plugins"]`
 - plugin `Cargo.toml` repository metadata points to `https://github.com/IBM/cpex-plugins`
 - plugin crate is listed in the top-level workspace `Cargo.toml`
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,8 +16,8 @@ Every managed plugin must satisfy the catalog contract enforced by `tools/plugin
 - Python module: `cpex_<slug>`
 - `Cargo.toml` is the version source of truth
 - `cpex_<slug>/plugin-manifest.yaml` version matches `Cargo.toml`
-- `cpex_<slug>/plugin-manifest.yaml` defines top-level `kind` in `module:object` form
-- `pyproject.toml` publishes the same plugin class reference under `[project.entry-points."cpex.plugins"]`
+- `cpex_<slug>/plugin-manifest.yaml` defines top-level `kind` in `module.object` form
+- `pyproject.toml` publishes the matching plugin class reference under `[project.entry-points."cpex.plugins"]` in `module:object` form
 - plugin `Cargo.toml` repository metadata points to `https://github.com/IBM/cpex-plugins`
 - plugin crate is listed in the top-level workspace `Cargo.toml`
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,6 +16,8 @@ Every managed plugin must satisfy the catalog contract enforced by `tools/plugin
 - Python module: `cpex_<slug>`
 - `Cargo.toml` is the version source of truth
 - `cpex_<slug>/plugin-manifest.yaml` version matches `Cargo.toml`
+- `cpex_<slug>/plugin-manifest.yaml` defines top-level `kind`
+- `pyproject.toml` publishes the same plugin class under `[project.entry-points."cpex.plugins"]`
 - plugin `Cargo.toml` repository metadata points to `https://github.com/IBM/cpex-plugins`
 - plugin crate is listed in the top-level workspace `Cargo.toml`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each managed plugin must include:
 - `cpex_<slug>/__init__.py`
 - `cpex_<slug>/plugin-manifest.yaml`
 
-Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, plugin manifests must declare a top-level `kind` in `module:object` form, and `pyproject.toml` must publish the same reference under `[project.entry-points."cpex.plugins"]`. Release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
+Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, plugin manifests must declare a top-level `kind` in `module.object` form, and `pyproject.toml` must publish the matching `module:object` reference under `[project.entry-points."cpex.plugins"]`. Release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
 
 ## Helper Commands
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each managed plugin must include:
 - `cpex_<slug>/__init__.py`
 - `cpex_<slug>/plugin-manifest.yaml`
 
-Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, plugin manifests must declare a top-level `kind`, and `pyproject.toml` must publish the same class path under `[project.entry-points."cpex.plugins"]`. Release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
+Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, plugin manifests must declare a top-level `kind` in `module:object` form, and `pyproject.toml` must publish the same reference under `[project.entry-points."cpex.plugins"]`. Release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
 
 ## Helper Commands
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each managed plugin must include:
 - `cpex_<slug>/__init__.py`
 - `cpex_<slug>/plugin-manifest.yaml`
 
-Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, and release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
+Rust crates are owned by the top-level workspace in `Cargo.toml`. Python package names follow `cpex-<slug>`, Python modules follow `cpex_<slug>`, plugin manifests must declare a top-level `kind`, and `pyproject.toml` must publish the same class path under `[project.entry-points."cpex.plugins"]`. Release tags use the hyphenated slug form `<slug-with-hyphens>-v<version>`, for example `rate-limiter-v0.0.2`.
 
 ## Helper Commands
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,6 +18,7 @@ They verify:
 - required files and package/module naming
 - workspace membership in the top-level `Cargo.toml`
 - version consistency between `Cargo.toml` and `plugin-manifest.yaml`
+- manifest `kind` consistency with `[project.entry-points."cpex.plugins"]`
 - repository metadata consistency
 - changed-plugin detection for CI
 - canonical release tag resolution

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,7 +18,7 @@ They verify:
 - required files and package/module naming
 - workspace membership in the top-level `Cargo.toml`
 - version consistency between `Cargo.toml` and `plugin-manifest.yaml`
-- manifest `kind` consistency with `[project.entry-points."cpex.plugins"]`
+- manifest `kind` consistency with `[project.entry-points."cpex.plugins"]` in canonical `module:object` form
 - repository metadata consistency
 - changed-plugin detection for CI
 - canonical release tag resolution

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,7 +18,7 @@ They verify:
 - required files and package/module naming
 - workspace membership in the top-level `Cargo.toml`
 - version consistency between `Cargo.toml` and `plugin-manifest.yaml`
-- manifest `kind` consistency with `[project.entry-points."cpex.plugins"]` in canonical `module:object` form
+- manifest `kind` consistency (`module.object`) with `[project.entry-points."cpex.plugins"]` targets (`module:object`)
 - repository metadata consistency
 - changed-plugin detection for CI
 - canonical release tag resolution

--- a/plugins/rust/python-package/pii_filter/cpex_pii_filter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/pii_filter/cpex_pii_filter/plugin-manifest.yaml
@@ -1,7 +1,7 @@
 description: "Rust-backed PII detection and masking for prompt arguments, tool inputs, and tool outputs"
 author: "ContextForge Contributors"
 version: "0.2.0"
-kind: "cpex_pii_filter.pii_filter:PIIFilterPlugin"
+kind: "cpex_pii_filter.pii_filter.PIIFilterPlugin"
 available_hooks:
   - "prompt_pre_fetch"
   - "prompt_post_fetch"

--- a/plugins/rust/python-package/pii_filter/cpex_pii_filter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/pii_filter/cpex_pii_filter/plugin-manifest.yaml
@@ -1,6 +1,7 @@
 description: "Rust-backed PII detection and masking for prompt arguments, tool inputs, and tool outputs"
 author: "ContextForge Contributors"
 version: "0.2.0"
+kind: "cpex_pii_filter.pii_filter:PIIFilterPlugin"
 available_hooks:
   - "prompt_pre_fetch"
   - "prompt_post_fetch"

--- a/plugins/rust/python-package/pii_filter/pyproject.toml
+++ b/plugins/rust/python-package/pii_filter/pyproject.toml
@@ -17,6 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+
+[project.entry-points."cpex.plugins"]
+pii_filter = "cpex_pii_filter.pii_filter:PIIFilterPlugin"
+
 [tool.maturin]
 module-name = "cpex_pii_filter.pii_filter_rust"
 python-source = "."

--- a/plugins/rust/python-package/rate_limiter/README.md
+++ b/plugins/rust/python-package/rate_limiter/README.md
@@ -17,7 +17,7 @@ If any configured dimension is exceeded, the plugin returns a violation with HTT
 
 ```yaml
 - name: RateLimiterPlugin
-  kind: cpex_rate_limiter.rate_limiter:RateLimiterPlugin
+  kind: cpex_rate_limiter.rate_limiter.RateLimiterPlugin
   hooks:
     - prompt_pre_fetch
     - tool_pre_invoke

--- a/plugins/rust/python-package/rate_limiter/README.md
+++ b/plugins/rust/python-package/rate_limiter/README.md
@@ -17,7 +17,7 @@ If any configured dimension is exceeded, the plugin returns a violation with HTT
 
 ```yaml
 - name: RateLimiterPlugin
-  kind: cpex_rate_limiter.rate_limiter.RateLimiterPlugin
+  kind: cpex_rate_limiter.rate_limiter:RateLimiterPlugin
   hooks:
     - prompt_pre_fetch
     - tool_pre_invoke

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,7 +1,7 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Contributors"
 version: "0.0.3"
-kind: "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"
+kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
 available_hooks:
   - "prompt_pre_fetch"
   - "tool_pre_invoke"

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,6 +1,7 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Contributors"
 version: "0.0.3"
+kind: "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"
 available_hooks:
   - "prompt_pre_fetch"
   - "tool_pre_invoke"

--- a/plugins/rust/python-package/rate_limiter/pyproject.toml
+++ b/plugins/rust/python-package/rate_limiter/pyproject.toml
@@ -17,6 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+
+[project.entry-points."cpex.plugins"]
+rate_limiter = "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"
+
 [tool.maturin]
 module-name = "cpex_rate_limiter.rate_limiter_rust"
 python-source = "."

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -56,11 +56,14 @@ class PluginCatalogTests(unittest.TestCase):
     def _create_plugin(self, root: Path, slug: str) -> Path:
         plugin_dir = root / "plugins" / "rust" / "python-package" / slug
         package_dir = plugin_dir / f"cpex_{slug}"
+        kind = f"cpex_{slug}.{slug}:{slug.title().replace('_', '')}Plugin"
         package_dir.mkdir(parents=True)
         (plugin_dir / "tests").mkdir()
         (plugin_dir / "pyproject.toml").write_text(
             (
                 f"[project]\nname = \"cpex-{slug.replace('_', '-')}\"\ndynamic = [\"version\"]\n\n"
+                "[project.entry-points.\"cpex.plugins\"]\n"
+                f"{slug} = \"{kind}\"\n\n"
                 "[tool.maturin]\n"
                 f"module-name = \"cpex_{slug}.{slug}_rust\"\n"
                 "python-source = \".\"\n"
@@ -73,7 +76,7 @@ class PluginCatalogTests(unittest.TestCase):
         (plugin_dir / "README.md").write_text(f"# {slug}\n")
         (package_dir / "__init__.py").write_text("")
         (package_dir / "plugin-manifest.yaml").write_text(
-            f'description: "{slug}"\nauthor: "ContextForge Team"\nversion: "0.0.1"\navailable_hooks:\n  - "tool_pre_invoke"\n'
+            f'description: "{slug}"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "{kind}"\navailable_hooks:\n  - "tool_pre_invoke"\n'
         )
         return plugin_dir
 
@@ -181,6 +184,93 @@ class PluginCatalogTests(unittest.TestCase):
             {entry["module_name"] for entry in payload["plugins"]},
             {"cpex_rate_limiter", "cpex_pii_filter"},
         )
+        self.assertEqual(
+            {entry["kind"] for entry in payload["plugins"]},
+            {
+                "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
+                "cpex_pii_filter.pii_filter:PIIFilterPlugin",
+            },
+        )
+
+    def test_validator_rejects_manifest_missing_kind(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing kind", result.stderr.lower())
+
+    def test_validator_rejects_missing_plugin_entry_point(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("project.entry-points", result.stderr.lower())
+
+    def test_validator_rejects_mismatched_manifest_kind_and_entry_point(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.other:OtherPlugin"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("kind mismatch", result.stderr.lower())
 
     def test_pii_manifest_defaults_match_runtime_defaults(self) -> None:
         manifest_defaults = self._parse_manifest_defaults(
@@ -257,6 +347,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "1.2.3"  # inline comment
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -334,13 +425,15 @@ class PluginCatalogTests(unittest.TestCase):
             pyproject = readme.parent / "pyproject.toml"
             pyproject.write_text(
                 "[project]\nname = \"cpex-rate-limiter\"\ndynamic = [\"version\"]\n\n"
+                "[project.entry-points.\"cpex.plugins\"]\n"
+                "rate_limiter = \"cpex_rate_limiter.rate_limiter:RateLimiterPlugin\"\n\n"
                 "[tool.maturin]\nmodule-name = \"cpex_rate_limiter.rate_limiter_rust\"\npython-source = \".\"\n"
             )
             package_dir = readme.parent / "cpex_rate_limiter"
             package_dir.mkdir()
             (package_dir / "__init__.py").write_text("")
             (package_dir / "plugin-manifest.yaml").write_text(
-                'description: "Rate limiter"\nauthor: "ContextForge Team"\nversion: "0.0.1"\navailable_hooks:\n  - "tool_pre_invoke"\n'
+                'description: "Rate limiter"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"\navailable_hooks:\n  - "tool_pre_invoke"\n'
             )
             (readme.parent / "Makefile").write_text("all:\n\t@true\n")
             (readme.parent / "tests").mkdir()

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -56,14 +56,16 @@ class PluginCatalogTests(unittest.TestCase):
     def _create_plugin(self, root: Path, slug: str) -> Path:
         plugin_dir = root / "plugins" / "rust" / "python-package" / slug
         package_dir = plugin_dir / f"cpex_{slug}"
-        kind = f"cpex_{slug}.{slug}:{slug.title().replace('_', '')}Plugin"
+        class_name = f"{slug.title().replace('_', '')}Plugin"
+        manifest_kind = f"cpex_{slug}.{slug}.{class_name}"
+        entry_point_kind = f"cpex_{slug}.{slug}:{class_name}"
         package_dir.mkdir(parents=True)
         (plugin_dir / "tests").mkdir()
         (plugin_dir / "pyproject.toml").write_text(
             (
                 f"[project]\nname = \"cpex-{slug.replace('_', '-')}\"\ndynamic = [\"version\"]\n\n"
                 "[project.entry-points.\"cpex.plugins\"]\n"
-                f"{slug} = \"{kind}\"\n\n"
+                f"{slug} = \"{entry_point_kind}\"\n\n"
                 "[tool.maturin]\n"
                 f"module-name = \"cpex_{slug}.{slug}_rust\"\n"
                 "python-source = \".\"\n"
@@ -76,7 +78,7 @@ class PluginCatalogTests(unittest.TestCase):
         (plugin_dir / "README.md").write_text(f"# {slug}\n")
         (package_dir / "__init__.py").write_text("")
         (package_dir / "plugin-manifest.yaml").write_text(
-            f'description: "{slug}"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "{kind}"\navailable_hooks:\n  - "tool_pre_invoke"\n'
+            f'description: "{slug}"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "{manifest_kind}"\navailable_hooks:\n  - "tool_pre_invoke"\n'
         )
         return plugin_dir
 
@@ -191,8 +193,8 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertEqual(
             {slug: entry["kind"] for slug, entry in by_slug.items()},
             {
-                "rate_limiter": "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
-                "pii_filter": "cpex_pii_filter.pii_filter:PIIFilterPlugin",
+                "rate_limiter": "cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
+                "pii_filter": "cpex_pii_filter.pii_filter.PIIFilterPlugin",
             },
         )
 
@@ -237,7 +239,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin" garbage
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin" garbage
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -413,7 +415,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.other:OtherPlugin"
+                    kind: "cpex_demo_plugin.other.OtherPlugin"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -440,7 +442,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -450,7 +452,7 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("module:object", result.stderr.lower())
+            self.assertIn("module.object", result.stderr.lower())
 
     def test_validator_rejects_equal_noncanonical_kind_strings(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -469,7 +471,7 @@ class PluginCatalogTests(unittest.TestCase):
                     dynamic = ["version"]
 
                     [project.entry-points."cpex.plugins"]
-                    demo_plugin = "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
 
                     [tool.maturin]
                     module-name = "cpex_demo_plugin.demo_plugin_rust"
@@ -484,7 +486,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -494,7 +496,7 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("module:object", result.stderr.lower())
+            self.assertIn("module.object", result.stderr.lower())
 
     def test_validator_rejects_noncanonical_entry_point_with_canonical_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -574,7 +576,7 @@ class PluginCatalogTests(unittest.TestCase):
                     dynamic = ["version"]
 
                     [project.entry-points."cpex.plugins"]
-                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin.nested"
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
 
                     [tool.maturin]
                     module-name = "cpex_demo_plugin.demo_plugin_rust"
@@ -589,7 +591,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin.nested"
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin.nested"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -599,7 +601,7 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("module:object", result.stderr.lower())
+            self.assertIn("kind mismatch", result.stderr.lower())
 
     def test_validator_rejects_entry_point_with_extras(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -633,7 +635,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin[extra]"
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin[extra]"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -643,7 +645,7 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("module:object", result.stderr.lower())
+            self.assertIn("module.object", result.stderr.lower())
 
     def test_validator_rejects_whitespace_padded_kind_reference(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -677,7 +679,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "0.0.1"
-                    kind: " cpex_demo_plugin.demo_plugin:DemoPluginPlugin "
+                    kind: " cpex_demo_plugin.demo_plugin.DemoPluginPlugin "
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -687,7 +689,7 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("module:object", result.stderr.lower())
+            self.assertIn("module.object", result.stderr.lower())
 
     def test_validator_rejects_nondict_project_table_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -951,7 +953,7 @@ class PluginCatalogTests(unittest.TestCase):
                     description: "Demo plugin"
                     author: "ContextForge Team"
                     version: "1.2.3"  # inline comment
-                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
                     available_hooks:
                       - "tool_pre_invoke"
                     """
@@ -1037,7 +1039,7 @@ class PluginCatalogTests(unittest.TestCase):
             package_dir.mkdir()
             (package_dir / "__init__.py").write_text("")
             (package_dir / "plugin-manifest.yaml").write_text(
-                'description: "Rate limiter"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"\navailable_hooks:\n  - "tool_pre_invoke"\n'
+                'description: "Rate limiter"\nauthor: "ContextForge Team"\nversion: "0.0.1"\nkind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"\navailable_hooks:\n  - "tool_pre_invoke"\n'
             )
             (readme.parent / "Makefile").write_text("all:\n\t@true\n")
             (readme.parent / "tests").mkdir()
@@ -1200,7 +1202,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertEqual(payload["slug"], "rate_limiter")
         self.assertEqual(
             payload["kind"],
-            "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
+            "cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
         )
         self.assertEqual(
             payload["release_wheel_matrix"],
@@ -1239,7 +1241,7 @@ class PluginCatalogTests(unittest.TestCase):
     def test_release_info_field_supports_kind(self) -> None:
         result = run_catalog("release-info-field", str(REPO_ROOT), "pii-filter-v0.2.0", "kind")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "cpex_pii_filter.pii_filter:PIIFilterPlugin")
+        self.assertEqual(result.stdout.strip(), "cpex_pii_filter.pii_filter.PIIFilterPlugin")
 
     def test_ci_selection_returns_has_plugins_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -526,6 +526,50 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("module:object", result.stderr.lower())
 
+    def test_validator_rejects_whitespace_padded_kind_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = " cpex_demo_plugin.demo_plugin:DemoPluginPlugin "
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: " cpex_demo_plugin.demo_plugin:DemoPluginPlugin "
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
+
     def test_validator_rejects_nondict_project_table_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -565,6 +609,100 @@ class PluginCatalogTests(unittest.TestCase):
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("cargo.toml", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_malformed_workspace_cargo_toml_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
+            (root / "Cargo.toml").write_text("[workspace\nmembers = []\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid toml", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_workspace_table_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
+            (root / "Cargo.toml").write_text("workspace = []\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("workspace", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_workspace_package_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
+            (root / "Cargo.toml").write_text("[workspace]\nmembers = []\npackage = []\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("workspace.package", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_project_dynamic_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = "version"
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("dynamic version", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_tool_maturin_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
+
+                    [tool]
+                    maturin = []
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("tool.maturin", result.stderr.lower())
             self.assertNotIn("traceback", result.stderr.lower())
 
     def test_validator_rejects_malformed_pyproject_toml_without_traceback(self) -> None:

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -438,6 +438,165 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertIn("module:object", result.stderr.lower())
             self.assertNotIn("traceback", result.stderr.lower())
 
+    def test_validator_rejects_nested_object_kind_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin.nested"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin.nested"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
+
+    def test_validator_rejects_entry_point_with_extras(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin[extra]"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin[extra]"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
+
+    def test_validator_rejects_nondict_project_table_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    project = []
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("project", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_cargo_package_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "Cargo.toml").write_text("package = []\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cargo.toml", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_malformed_pyproject_toml_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text("[project\nname = 'broken'\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid toml", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_malformed_cargo_toml_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "Cargo.toml").write_text("[package\nname = 'broken'\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid toml", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
     def test_pii_manifest_defaults_match_runtime_defaults(self) -> None:
         manifest_defaults = self._parse_manifest_defaults(
             REPO_ROOT

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -222,6 +222,33 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("missing kind", result.stderr.lower())
 
+    def test_validator_rejects_manifest_kind_with_trailing_junk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.demo_plugin:DemoPluginPlugin" garbage
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("trailing content", result.stderr.lower())
+
     def test_validator_rejects_missing_plugin_entry_point(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -248,6 +275,66 @@ class PluginCatalogTests(unittest.TestCase):
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("project.entry-points", result.stderr.lower())
+
+    def test_validator_rejects_nondict_project_entry_points_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+                    entry-points = []
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("entry-points", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nondict_cpex_plugins_entry_points_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points]
+                    cpex.plugins = []
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cpex.plugins", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
 
     def test_validator_rejects_missing_slug_specific_plugin_entry_point(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -627,6 +714,17 @@ class PluginCatalogTests(unittest.TestCase):
             root = Path(tmpdir)
             (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
             (root / "Cargo.toml").write_text("workspace = []\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("workspace", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nonlist_workspace_members_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
+            (root / "Cargo.toml").write_text("[workspace]\nmembers = \"demo_plugin\"\n")
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -336,6 +336,38 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertIn("cpex.plugins", result.stderr.lower())
             self.assertNotIn("traceback", result.stderr.lower())
 
+    def test_validator_rejects_nonstring_sibling_cpex_plugins_entry_point_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
+                    other = 123
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cpex.plugins", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
     def test_validator_rejects_missing_slug_specific_plugin_entry_point(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -725,6 +757,17 @@ class PluginCatalogTests(unittest.TestCase):
             root = Path(tmpdir)
             (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
             (root / "Cargo.toml").write_text("[workspace]\nmembers = \"demo_plugin\"\n")
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("workspace", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
+    def test_validator_rejects_nonstr_workspace_member_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "plugins" / "rust" / "python-package").mkdir(parents=True)
+            (root / "Cargo.toml").write_text('[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin", 123]\n')
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -377,6 +377,67 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("module:object", result.stderr.lower())
 
+    def test_validator_rejects_noncanonical_entry_point_with_canonical_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
+
+    def test_validator_rejects_malformed_entry_point_without_traceback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin:"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
+            self.assertNotIn("traceback", result.stderr.lower())
+
     def test_pii_manifest_defaults_match_runtime_defaults(self) -> None:
         manifest_defaults = self._parse_manifest_defaults(
             REPO_ROOT
@@ -699,6 +760,10 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["slug"], "rate_limiter")
+        self.assertEqual(
+            payload["kind"],
+            "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
+        )
         self.assertEqual(
             payload["release_wheel_matrix"],
             [

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -272,6 +272,33 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("kind mismatch", result.stderr.lower())
 
+    def test_validator_rejects_noncanonical_manifest_kind_separator(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("kind mismatch", result.stderr.lower())
+
     def test_pii_manifest_defaults_match_runtime_defaults(self) -> None:
         manifest_defaults = self._parse_manifest_defaults(
             REPO_ROOT
@@ -627,6 +654,11 @@ class PluginCatalogTests(unittest.TestCase):
         result = run_catalog("release-info", str(REPO_ROOT), "rate_limiter-v0.0.3")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("canonical", result.stderr.lower())
+
+    def test_release_info_field_supports_kind(self) -> None:
+        result = run_catalog("release-info-field", str(REPO_ROOT), "pii-filter-v0.2.0", "kind")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "cpex_pii_filter.pii_filter:PIIFilterPlugin")
 
     def test_ci_selection_returns_has_plugins_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -180,15 +180,19 @@ class PluginCatalogTests(unittest.TestCase):
             {entry["slug"] for entry in payload["plugins"]},
             {"rate_limiter", "pii_filter"},
         )
+        by_slug = {entry["slug"]: entry for entry in payload["plugins"]}
         self.assertEqual(
-            {entry["module_name"] for entry in payload["plugins"]},
-            {"cpex_rate_limiter", "cpex_pii_filter"},
+            {slug: entry["module_name"] for slug, entry in by_slug.items()},
+            {
+                "rate_limiter": "cpex_rate_limiter",
+                "pii_filter": "cpex_pii_filter",
+            },
         )
         self.assertEqual(
-            {entry["kind"] for entry in payload["plugins"]},
+            {slug: entry["kind"] for slug, entry in by_slug.items()},
             {
-                "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
-                "cpex_pii_filter.pii_filter:PIIFilterPlugin",
+                "rate_limiter": "cpex_rate_limiter.rate_limiter:RateLimiterPlugin",
+                "pii_filter": "cpex_pii_filter.pii_filter:PIIFilterPlugin",
             },
         )
 
@@ -245,6 +249,36 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("project.entry-points", result.stderr.lower())
 
+    def test_validator_rejects_missing_slug_specific_plugin_entry_point(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    other_plugin = "cpex_demo_plugin.demo_plugin:DemoPluginPlugin"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("entry point", result.stderr.lower())
+
     def test_validator_rejects_mismatched_manifest_kind_and_entry_point(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -297,7 +331,51 @@ class PluginCatalogTests(unittest.TestCase):
 
             result = run_catalog("validate", str(root))
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("kind mismatch", result.stderr.lower())
+            self.assertIn("module:object", result.stderr.lower())
+
+    def test_validator_rejects_equal_noncanonical_kind_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/demo_plugin"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n',
+            )
+            plugin_dir = self._create_plugin(root, "demo_plugin")
+            package_dir = plugin_dir / "cpex_demo_plugin"
+            (plugin_dir / "pyproject.toml").write_text(
+                textwrap.dedent(
+                    """
+                    [project]
+                    name = "cpex-demo-plugin"
+                    dynamic = ["version"]
+
+                    [project.entry-points."cpex.plugins"]
+                    demo_plugin = "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+
+                    [tool.maturin]
+                    module-name = "cpex_demo_plugin.demo_plugin_rust"
+                    python-source = "."
+                    """
+                ).strip()
+                + "\n"
+            )
+            (package_dir / "plugin-manifest.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    description: "Demo plugin"
+                    author: "ContextForge Team"
+                    version: "0.0.1"
+                    kind: "cpex_demo_plugin.demo_plugin.DemoPluginPlugin"
+                    available_hooks:
+                      - "tool_pre_invoke"
+                    """
+                ).strip()
+                + "\n"
+            )
+
+            result = run_catalog("validate", str(root))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("module:object", result.stderr.lower())
 
     def test_pii_manifest_defaults_match_runtime_defaults(self) -> None:
         manifest_defaults = self._parse_manifest_defaults(

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -79,6 +79,11 @@ def _manifest_scalar(manifest_path: Path, key_name: str) -> str:
             if closing_index == -1:
                 candidate = raw_candidate
             else:
+                trailing = raw_candidate[closing_index + 1 :].strip()
+                if trailing and not trailing.startswith("#"):
+                    raise CatalogError(
+                        f"Invalid trailing content for {key_name} in {manifest_path}"
+                    )
                 candidate = ast.literal_eval(raw_candidate[: closing_index + 1])
         else:
             candidate = raw_candidate.split("#", maxsplit=1)[0].strip()

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -257,7 +257,7 @@ def validate_plugin_dir(
 
     manifest_kind = _manifest_kind(manifest_path)
     entry_point = _project_entry_point(pyproject, slug)
-    if manifest_kind.replace(":", ".") != entry_point.replace(":", "."):
+    if manifest_kind != entry_point:
         raise CatalogError(
             f"{plugin_dir}: kind mismatch between plugin-manifest.yaml ({manifest_kind}) and pyproject.toml entry point ({entry_point})"
         )
@@ -429,6 +429,7 @@ def build_parser() -> argparse.ArgumentParser:
             "path",
             "package_name",
             "module_name",
+            "kind",
             "version",
             "release_wheel_matrix",
         ),

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -29,8 +29,11 @@ SHARED_PATH_PREFIXES = (
     "tools/",
 )
 
-KIND_REFERENCE_PATTERN = re.compile(
+ENTRY_POINT_PATTERN = re.compile(
     r"^(?P<module>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*):(?P<object>[A-Za-z_][A-Za-z0-9_]*)$"
+)
+MANIFEST_KIND_PATTERN = re.compile(
+    r"^(?P<module>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\.(?P<object>[A-Za-z_][A-Za-z0-9_]*)$"
 )
 
 
@@ -153,8 +156,19 @@ def _project_entry_point(pyproject: dict, slug: str) -> str:
     return entry_point
 
 
-def _validate_kind_reference(value: str, source: str) -> str:
-    if KIND_REFERENCE_PATTERN.fullmatch(value) is None:
+def _manifest_kind_to_entry_point(value: str, source: str) -> str:
+    match = MANIFEST_KIND_PATTERN.fullmatch(value)
+    if match is None:
+        raise CatalogError(
+            f"{source}: kind must use canonical module.object form, got {value}"
+        )
+    module = match.group("module")
+    object_name = match.group("object")
+    return f"{module}:{object_name}"
+
+
+def _validate_entry_point_target(value: str, source: str) -> str:
+    if ENTRY_POINT_PATTERN.fullmatch(value) is None:
         raise CatalogError(
             f"{source}: kind must use canonical module:object form, got {value}"
         )
@@ -312,10 +326,12 @@ def validate_plugin_dir(
         )
 
     manifest_kind = _manifest_kind(manifest_path)
+    manifest_entry_point = _manifest_kind_to_entry_point(manifest_kind, str(manifest_path))
     entry_point = _project_entry_point(pyproject, slug)
-    _validate_kind_reference(manifest_kind, str(manifest_path))
-    _validate_kind_reference(entry_point, f"{plugin_dir / 'pyproject.toml'} entry point {slug!r}")
-    if manifest_kind != entry_point:
+    entry_point = _validate_entry_point_target(
+        entry_point, f"{plugin_dir / 'pyproject.toml'} entry point {slug!r}"
+    )
+    if manifest_entry_point != entry_point:
         raise CatalogError(
             f"{plugin_dir}: kind mismatch between plugin-manifest.yaml ({manifest_kind}) and pyproject.toml entry point ({entry_point})"
         )
@@ -325,7 +341,7 @@ def validate_plugin_dir(
         path=relative_plugin_path,
         package_name=expected_package_name,
         module_name=expected_module_name,
-        kind=entry_point,
+        kind=manifest_kind,
         version=version,
         release_wheel_matrix=_release_wheel_matrix(),
     )

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from importlib.metadata import EntryPoint
 from pathlib import Path
 
 
@@ -26,6 +26,10 @@ SHARED_PATH_PREFIXES = (
     "TESTING.md",
     "tests/",
     "tools/",
+)
+
+KIND_REFERENCE_PATTERN = re.compile(
+    r"^(?P<module>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*):(?P<object>[A-Za-z_][A-Za-z0-9_]*)$"
 )
 
 
@@ -85,13 +89,19 @@ def _manifest_kind(manifest_path: Path) -> str:
 
 
 def _parse_pyproject(pyproject_path: Path) -> dict:
-    with pyproject_path.open("rb") as handle:
-        return tomllib.load(handle)
+    try:
+        with pyproject_path.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        raise CatalogError(f"Invalid TOML in {pyproject_path}: {exc}") from exc
 
 
 def _parse_cargo(cargo_path: Path) -> dict:
-    with cargo_path.open("rb") as handle:
-        return tomllib.load(handle)
+    try:
+        with cargo_path.open("rb") as handle:
+            return tomllib.load(handle)
+    except tomllib.TOMLDecodeError as exc:
+        raise CatalogError(f"Invalid TOML in {cargo_path}: {exc}") from exc
 
 
 def _expected_package_name(slug: str) -> str:
@@ -108,6 +118,8 @@ def _expected_maturin_module_name(slug: str) -> str:
 
 def _project_entry_point(pyproject: dict, slug: str) -> str:
     project = pyproject.get("project", {})
+    if not isinstance(project, dict):
+        raise CatalogError("pyproject.toml [project] must be a table")
     entry_points = project.get("entry-points", {}) if isinstance(project, dict) else {}
     if not isinstance(entry_points, dict):
         raise CatalogError("pyproject.toml project.entry-points must be a table")
@@ -123,14 +135,7 @@ def _project_entry_point(pyproject: dict, slug: str) -> str:
 
 
 def _validate_kind_reference(value: str, source: str) -> str:
-    try:
-        entry_point = EntryPoint(name="plugin", value=value, group="cpex.plugins")
-        attr = entry_point.attr
-    except AssertionError as exc:
-        raise CatalogError(
-            f"{source}: kind must use canonical module:object form, got {value}"
-        ) from exc
-    if attr is None:
+    if KIND_REFERENCE_PATTERN.fullmatch(value) is None:
         raise CatalogError(
             f"{source}: kind must use canonical module:object form, got {value}"
         )
@@ -218,9 +223,13 @@ def validate_plugin_dir(
     cargo = _parse_cargo(plugin_dir / "Cargo.toml")
 
     project = pyproject.get("project", {})
+    if not isinstance(project, dict):
+        raise CatalogError(f"{plugin_dir}: pyproject.toml [project] must be a table")
     tool = pyproject.get("tool", {})
     maturin = tool.get("maturin", {}) if isinstance(tool, dict) else {}
     package = cargo.get("package", {})
+    if not isinstance(package, dict):
+        raise CatalogError(f"{plugin_dir}: Cargo.toml [package] must be a table")
     relative_plugin_path = str(plugin_dir.relative_to(root))
 
     if relative_plugin_path not in workspace_members:

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -123,8 +123,14 @@ def _project_entry_point(pyproject: dict, slug: str) -> str:
 
 
 def _validate_kind_reference(value: str, source: str) -> str:
-    entry_point = EntryPoint(name="plugin", value=value, group="cpex.plugins")
-    if entry_point.attr is None:
+    try:
+        entry_point = EntryPoint(name="plugin", value=value, group="cpex.plugins")
+        attr = entry_point.attr
+    except AssertionError as exc:
+        raise CatalogError(
+            f"{source}: kind must use canonical module:object form, got {value}"
+        ) from exc
+    if attr is None:
         raise CatalogError(
             f"{source}: kind must use canonical module:object form, got {value}"
         )

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -143,6 +143,8 @@ def _project_entry_point(pyproject: dict, slug: str) -> str:
     cpex_plugins = entry_points.get("cpex.plugins")
     if not isinstance(cpex_plugins, dict):
         raise CatalogError('pyproject.toml must define [project.entry-points."cpex.plugins"]')
+    if any(not isinstance(name, str) or not isinstance(value, str) for name, value in cpex_plugins.items()):
+        raise CatalogError('pyproject.toml [project.entry-points."cpex.plugins"] must map plugin names to strings')
     entry_point = cpex_plugins.get(slug)
     if not isinstance(entry_point, str) or not entry_point:
         raise CatalogError(
@@ -198,7 +200,9 @@ def _workspace_members(root: Path) -> set[str]:
     members = workspace.get("members")
     if not isinstance(members, list):
         raise CatalogError("Workspace Cargo.toml must define [workspace].members")
-    return {str(member) for member in members}
+    if any(not isinstance(member, str) for member in members):
+        raise CatalogError("Workspace Cargo.toml [workspace].members must contain only strings")
+    return set(members)
 
 
 def _workspace_package_metadata(root: Path) -> dict:

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
+from importlib.metadata import EntryPoint
 from pathlib import Path
 
 
@@ -119,6 +120,15 @@ def _project_entry_point(pyproject: dict, slug: str) -> str:
             f'pyproject.toml must define entry point {slug!r} in [project.entry-points."cpex.plugins"]'
         )
     return entry_point
+
+
+def _validate_kind_reference(value: str, source: str) -> str:
+    entry_point = EntryPoint(name="plugin", value=value, group="cpex.plugins")
+    if entry_point.attr is None:
+        raise CatalogError(
+            f"{source}: kind must use canonical module:object form, got {value}"
+        )
+    return value
 
 
 def discover_plugins(root: Path) -> list[PluginRecord]:
@@ -257,6 +267,8 @@ def validate_plugin_dir(
 
     manifest_kind = _manifest_kind(manifest_path)
     entry_point = _project_entry_point(pyproject, slug)
+    _validate_kind_reference(manifest_kind, str(manifest_path))
+    _validate_kind_reference(entry_point, f"{plugin_dir / 'pyproject.toml'} entry point {slug!r}")
     if manifest_kind != entry_point:
         raise CatalogError(
             f"{plugin_dir}: kind mismatch between plugin-manifest.yaml ({manifest_kind}) and pyproject.toml entry point ({entry_point})"

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -38,6 +38,7 @@ class PluginRecord:
     path: str
     package_name: str
     module_name: str
+    kind: str
     version: str
     release_wheel_matrix: list[dict[str, str]]
 
@@ -53,25 +54,33 @@ def _release_wheel_matrix() -> list[dict[str, str]]:
     ]
 
 
-def _manifest_version(manifest_path: Path) -> str:
-    version: str | None = None
+def _manifest_scalar(manifest_path: Path, key_name: str) -> str:
+    value: str | None = None
     for line in manifest_path.read_text(encoding="utf-8").splitlines():
         if not line or line[:1].isspace():
             continue
         key, separator, raw_value = line.partition(":")
         if separator != ":":
             continue
-        if key.strip() != "version":
+        if key.strip() != key_name:
             continue
         candidate = raw_value.split("#", maxsplit=1)[0].strip().strip('"').strip("'")
         if not candidate:
-            raise CatalogError(f"Empty version in {manifest_path}")
-        if version is not None:
-            raise CatalogError(f"Duplicate top-level version in {manifest_path}")
-        version = candidate
-    if version is not None:
-        return version
-    raise CatalogError(f"Missing version in {manifest_path}")
+            raise CatalogError(f"Empty {key_name} in {manifest_path}")
+        if value is not None:
+            raise CatalogError(f"Duplicate top-level {key_name} in {manifest_path}")
+        value = candidate
+    if value is not None:
+        return value
+    raise CatalogError(f"Missing {key_name} in {manifest_path}")
+
+
+def _manifest_version(manifest_path: Path) -> str:
+    return _manifest_scalar(manifest_path, "version")
+
+
+def _manifest_kind(manifest_path: Path) -> str:
+    return _manifest_scalar(manifest_path, "kind")
 
 
 def _parse_pyproject(pyproject_path: Path) -> dict:
@@ -94,6 +103,22 @@ def _expected_module_name(slug: str) -> str:
 
 def _expected_maturin_module_name(slug: str) -> str:
     return f"{_expected_module_name(slug)}.{slug}_rust"
+
+
+def _project_entry_point(pyproject: dict, slug: str) -> str:
+    project = pyproject.get("project", {})
+    entry_points = project.get("entry-points", {}) if isinstance(project, dict) else {}
+    if not isinstance(entry_points, dict):
+        raise CatalogError("pyproject.toml project.entry-points must be a table")
+    cpex_plugins = entry_points.get("cpex.plugins")
+    if not isinstance(cpex_plugins, dict):
+        raise CatalogError('pyproject.toml must define [project.entry-points."cpex.plugins"]')
+    entry_point = cpex_plugins.get(slug)
+    if not isinstance(entry_point, str) or not entry_point:
+        raise CatalogError(
+            f'pyproject.toml must define entry point {slug!r} in [project.entry-points."cpex.plugins"]'
+        )
+    return entry_point
 
 
 def discover_plugins(root: Path) -> list[PluginRecord]:
@@ -230,11 +255,19 @@ def validate_plugin_dir(
             f"{plugin_dir}: version mismatch between Cargo.toml ({version}) and plugin-manifest.yaml ({manifest_version})"
         )
 
+    manifest_kind = _manifest_kind(manifest_path)
+    entry_point = _project_entry_point(pyproject, slug)
+    if manifest_kind.replace(":", ".") != entry_point.replace(":", "."):
+        raise CatalogError(
+            f"{plugin_dir}: kind mismatch between plugin-manifest.yaml ({manifest_kind}) and pyproject.toml entry point ({entry_point})"
+        )
+
     return PluginRecord(
         slug=slug,
         path=relative_plugin_path,
         package_name=expected_package_name,
         module_name=expected_module_name,
+        kind=entry_point,
         version=version,
         release_wheel_matrix=_release_wheel_matrix(),
     )

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import re
 import subprocess
@@ -69,7 +70,18 @@ def _manifest_scalar(manifest_path: Path, key_name: str) -> str:
             continue
         if key.strip() != key_name:
             continue
-        candidate = raw_value.split("#", maxsplit=1)[0].strip().strip('"').strip("'")
+        raw_candidate = raw_value.strip()
+        if raw_candidate[:1] in {'"', "'"}:
+            quote = raw_candidate[:1]
+            closing_index = raw_candidate.find(quote, 1)
+            while closing_index != -1 and raw_candidate[closing_index - 1] == "\\":
+                closing_index = raw_candidate.find(quote, closing_index + 1)
+            if closing_index == -1:
+                candidate = raw_candidate
+            else:
+                candidate = ast.literal_eval(raw_candidate[: closing_index + 1])
+        else:
+            candidate = raw_candidate.split("#", maxsplit=1)[0].strip()
         if not candidate:
             raise CatalogError(f"Empty {key_name} in {manifest_path}")
         if value is not None:
@@ -176,6 +188,8 @@ def _workspace_members(root: Path) -> set[str]:
         raise CatalogError(f"Workspace Cargo.toml not found at {cargo_toml}")
     cargo = _parse_cargo(cargo_toml)
     workspace = cargo.get("workspace", {})
+    if not isinstance(workspace, dict):
+        raise CatalogError("Workspace Cargo.toml must define [workspace] metadata as a table")
     members = workspace.get("members")
     if not isinstance(members, list):
         raise CatalogError("Workspace Cargo.toml must define [workspace].members")
@@ -188,6 +202,8 @@ def _workspace_package_metadata(root: Path) -> dict:
         raise CatalogError(f"Workspace Cargo.toml not found at {cargo_toml}")
     cargo = _parse_cargo(cargo_toml)
     workspace = cargo.get("workspace", {})
+    if not isinstance(workspace, dict):
+        raise CatalogError("Workspace Cargo.toml must define [workspace] metadata as a table")
     package = workspace.get("package", {})
     if not isinstance(package, dict):
         raise CatalogError("Workspace Cargo.toml must define [workspace.package] metadata")
@@ -227,6 +243,8 @@ def validate_plugin_dir(
         raise CatalogError(f"{plugin_dir}: pyproject.toml [project] must be a table")
     tool = pyproject.get("tool", {})
     maturin = tool.get("maturin", {}) if isinstance(tool, dict) else {}
+    if not isinstance(maturin, dict):
+        raise CatalogError(f"{plugin_dir}: pyproject.toml tool.maturin must be a table")
     package = cargo.get("package", {})
     if not isinstance(package, dict):
         raise CatalogError(f"{plugin_dir}: Cargo.toml [package] must be a table")
@@ -244,6 +262,10 @@ def validate_plugin_dir(
         )
 
     dynamic = project.get("dynamic", [])
+    if not isinstance(dynamic, list) or any(not isinstance(item, str) for item in dynamic):
+        raise CatalogError(
+            f"{plugin_dir}: pyproject.toml must declare dynamic version sourced from Cargo.toml"
+        )
     if "version" not in dynamic or "version" in project:
         raise CatalogError(
             f"{plugin_dir}: pyproject.toml must declare dynamic version sourced from Cargo.toml"


### PR DESCRIPTION
## Summary
- require each plugin manifest to declare an explicit `kind`
- publish the same plugin class path through `[project.entry-points."cpex.plugins"]`
- expose and validate `kind` in `tools/plugin_catalog.py`, with tests and docs updated accordingly

## Why
Issue #12 identified that PyPI package installation is deterministic, but plugin class discovery was still implicit. This change makes the plugin class path an explicit repository contract while also exposing a standard Python entry point for runtime discovery.

Closes #12

## Validation
- `python3 -m unittest tests.test_plugin_catalog`
- `python3 -m unittest tests.test_install_built_wheel`
- `python3 tools/plugin_catalog.py validate .`
