### PR TITLE
Add CODEOWNERS for current contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lucarlig @gandhipratik203 @msureshkumar88


### PR DESCRIPTION
## What changed
Add a repo-wide `.github/CODEOWNERS` file that assigns ownership of all paths to the current human committers in this repository.

## Why
This makes the default ownership explicit for review routing and future changes across the monorepo.

## Impact
GitHub can now use the three current contributor accounts as owners for all files:
- `@lucarlig`
- `@gandhipratik203`
- `@msureshkumar88`

## Validation
- Verified the repo commit history to resolve contributor GitHub handles.
- Verified `.github/CODEOWNERS` contains the expected catch-all entry.
