### PR TITLE
Add pii_filter frozen payload regression tests

### DIFF
--- a/plugins/tests/pii_filter/test_integration.py
+++ b/plugins/tests/pii_filter/test_integration.py
@@ -234,6 +234,22 @@ async def test_tool_pre_invoke_masks_nested_args_through_python_shim():
 
 
 @pytest.mark.asyncio
+async def test_tool_pre_invoke_returns_copied_payload_for_frozen_models():
+    plugin = PIIFilterPlugin(_make_config())
+    payload = ToolPreInvokePayload(
+        name="search",
+        args={"user": {"email": "alice@example.com"}},
+    )
+
+    result = await plugin.tool_pre_invoke(payload, _make_context())
+
+    assert result.modified_payload is not None
+    assert result.modified_payload is not payload
+    assert payload.args["user"]["email"] == "alice@example.com"
+    assert result.modified_payload.args["user"]["email"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
 async def test_tool_pre_invoke_propagates_nested_depth_errors():
     plugin = PIIFilterPlugin(_make_config(max_nested_depth=1))
     payload = ToolPreInvokePayload(
@@ -262,6 +278,22 @@ async def test_tool_post_invoke_masks_result_and_updates_context_through_python_
         "total_detections": 1,
         "total_masked": 1,
     }
+
+
+@pytest.mark.asyncio
+async def test_tool_post_invoke_returns_copied_payload_for_frozen_models():
+    plugin = PIIFilterPlugin(_make_config())
+    payload = ToolPostInvokePayload(
+        name="search",
+        result={"contact": "alice@example.com"},
+    )
+
+    result = await plugin.tool_post_invoke(payload, _make_context())
+
+    assert result.modified_payload is not None
+    assert result.modified_payload is not payload
+    assert payload.result["contact"] == "alice@example.com"
+    assert result.modified_payload.result["contact"] == "[REDACTED]"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add regression tests covering frozen `ToolPreInvokePayload` and `ToolPostInvokePayload`
- verify the PII filter returns a copied payload instead of mutating the original frozen model
- lock in the behavior reported in #41, which appears already fixed in the Rust core

## Root cause
Issue #41 reports runtime failures when the plugin mutates frozen Pydantic payload models in place. The current implementation already avoids that by cloning payloads via `model_copy(update=...)`. These tests prove that behavior explicitly and guard against regressions.

## Validation
- `uv run pytest ../../../tests/pii_filter/test_integration.py -q`
- manual reproduction of the old failure mode by assigning to `ToolPostInvokePayload.result`, which still raises the expected frozen-instance `ValidationError`

Closes #41
