### PR TITLE
Add Rust native retry policy

### DIFF
--- a/.github/workflows/ci-install-built-wheel.yaml
+++ b/.github/workflows/ci-install-built-wheel.yaml
@@ -47,6 +47,6 @@ jobs:
     needs: test
     uses: ./.github/workflows/release-rust-python-package.yaml
     with:
-      tag: retry-with-backoff-v0.1.1
+      tag: retry-with-backoff-v0.2.0
       repository: testpypi
       publish_enabled: false

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -247,6 +247,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/release-rust-python-package.yaml
     with:
-      tag: retry-with-backoff-v0.1.1
+      tag: retry-with-backoff-v0.2.0
       repository: testpypi
       publish_enabled: false

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -42,9 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       plugin: ${{ steps.resolve.outputs.plugin }}
+      slug: ${{ steps.resolve.outputs.plugin }}
       plugin_path: ${{ steps.resolve.outputs.plugin_path }}
       wheel_matrix: ${{ steps.resolve.outputs.wheel_matrix }}
       publish_env: ${{ steps.resolve.outputs.publish_env }}
+      publish_enabled: ${{ steps.resolve.outputs.publish_enabled }}
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}
     steps:
@@ -62,16 +64,25 @@ jobs:
         env:
           TAG_INPUT: ${{ inputs.tag }}
           REPOSITORY_INPUT: ${{ inputs.repository }}
+          PUBLISH_ENABLED: ${{ inputs.publish_enabled }}
         run: |
           set -euo pipefail
           git fetch --force origin "refs/heads/main:refs/remotes/origin/main"
           if [[ -n "${TAG_INPUT}" ]]; then
             tag="${TAG_INPUT}"
             repository="${REPOSITORY_INPUT}"
-            git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
-            git show-ref --verify --quiet "refs/tags/${tag}"
-            checkout_ref="refs/tags/${tag}"
-            tag_ref="refs/tags/${tag}"
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
+              git show-ref --verify --quiet "refs/tags/${tag}"
+              checkout_ref="refs/tags/${tag}"
+              tag_ref="refs/tags/${tag}"
+            elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${PUBLISH_ENABLED}" == "false" ]]; then
+              checkout_ref="${GITHUB_SHA}"
+              tag_ref="${GITHUB_SHA}"
+            else
+              echo "Release tag ${tag} does not exist" >&2
+              exit 1
+            fi
           else
             tag="${GITHUB_REF_NAME}"
             repository="pypi"
@@ -100,6 +111,11 @@ jobs:
             echo "wheel_matrix=${wheel_matrix}"
             echo "checkout_ref=${checkout_ref}"
             echo "tag_on_main=${tag_on_main}"
+            if [[ "${PUBLISH_ENABLED}" == "false" ]]; then
+              echo "publish_enabled=false"
+            else
+              echo "publish_enabled=true"
+            fi
             if [[ "${repository}" == "testpypi" ]]; then
               echo "publish_env=testpypi"
             else
@@ -265,7 +281,7 @@ jobs:
           fi
 
   publish:
-    if: ${{ (github.event_name != 'workflow_call' || inputs.publish_enabled) && (needs.resolve.outputs.publish_env != 'pypi' || needs.resolve.outputs.tag_on_main == 'true') }}
+    if: ${{ needs.resolve.outputs.publish_enabled == 'true' && (needs.resolve.outputs.publish_env != 'pypi' || needs.resolve.outputs.tag_on_main == 'true') }}
     needs: [resolve, build-wheel, build-sdist]
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve.outputs.publish_env }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "retry_with_backoff"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "log",
  "pyo3",

--- a/plugins/rust/python-package/retry_with_backoff/Cargo.toml
+++ b/plugins/rust/python-package/retry_with_backoff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry_with_backoff"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/retry_with_backoff/Makefile
+++ b/plugins/rust/python-package/retry_with_backoff/Makefile
@@ -5,8 +5,14 @@ help:
 PACKAGE_NAME := cpex-retry-with-backoff
 WHEEL_PREFIX := cpex_retry_with_backoff
 CARGO := cargo
+CARGO_PACKAGE := retry_with_backoff
+PLUGIN_SLUG := retry_with_backoff
+REPO_ROOT := ../../../..
 STUB_FILES := cpex_retry_with_backoff/__init__.pyi cpex_retry_with_backoff/retry_with_backoff_rust/__init__.pyi
 WHEEL_DIR := ../../../../target/wheels
+COVERAGE_REPORT := coverage/cobertura.xml
+COVERAGE_MIN := 90.00
+CARGO_LLVM_COV_VERSION := 0.8.4
 
 GREEN := \033[0;32m
 YELLOW := \033[0;33m
@@ -101,8 +107,9 @@ clean-all: clean
 # help: verify                - Verify plugin installation
 # help: check-all             - Run fmt-check + clippy + Rust tests
 # help: ci-build              - Run CI build/static verification without integration tests
+# help: coverage              - Generate Rust coverage and enforce the 90% floor
 # help: ci                    - Run the full CI-equivalent plugin verification flow
-.PHONY: verify check-all ci-build ci pre-commit
+.PHONY: verify check-all ci-build coverage ci pre-commit
 
 verify:
 	@uv run python -c "from cpex_retry_with_backoff import retry_with_backoff_rust; print('retry_with_backoff_rust available')" || echo "retry_with_backoff_rust not installed — run: make install"
@@ -112,7 +119,24 @@ check-all: fmt-check clippy test-unit
 
 ci-build: check-all verify-stubs build install-wheel
 
-ci: ci-build test-integration
+coverage:
+	@echo "$(GREEN)Generating Rust coverage...$(NC)"
+	mkdir -p $(REPO_ROOT)/coverage
+	rustup component add llvm-tools-preview
+	cargo llvm-cov --version >/dev/null 2>&1 || cargo install cargo-llvm-cov --version $(CARGO_LLVM_COV_VERSION) --locked
+	cargo llvm-cov clean --workspace
+	eval "$$(cargo llvm-cov show-env --sh)" && \
+	export CARGO_TARGET_DIR="$${CARGO_LLVM_COV_TARGET_DIR}/llvm-cov-target" && \
+	export CARGO_LLVM_COV_BUILD_DIR="$${CARGO_TARGET_DIR}" && \
+	export LLVM_PROFILE_FILE="$${CARGO_TARGET_DIR}/cpex-plugins-%p-%10m.profraw" && \
+	mkdir -p "$${CARGO_TARGET_DIR}" && \
+	uv run maturin develop && \
+	$(CARGO) test -p $(CARGO_PACKAGE) && \
+	$(MAKE) test-integration && \
+	env -u CARGO_TARGET_DIR -u CARGO_LLVM_COV_BUILD_DIR -u CARGO_LLVM_COV_TARGET_DIR -u LLVM_PROFILE_FILE cargo llvm-cov report -p $(CARGO_PACKAGE) --cobertura --output-path $(REPO_ROOT)/$(COVERAGE_REPORT)
+	python3 $(REPO_ROOT)/tools/plugin_catalog.py coverage-check $(REPO_ROOT) $(COVERAGE_REPORT) $(COVERAGE_MIN) '["$(PLUGIN_SLUG)"]'
+
+ci: ci-build test-integration coverage
 	@echo "$(GREEN)CI verification passed$(NC)"
 
 pre-commit: check-all

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/plugin-manifest.yaml
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "High-performance retry policy engine with exponential backoff, jitter, per-tool overrides, and retry metadata for transient tool and resource failures"
 author: "ContextForge Contributors"
-version: "0.1.1"
+version: "0.2.0"
 kind: "cpex_retry_with_backoff.retry_with_backoff.RetryWithBackoffPlugin"
 available_hooks:
   - "tool_post_invoke"

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
@@ -9,7 +9,7 @@ import math
 import random
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -166,6 +166,24 @@ class RetryWithBackoffPlugin(Plugin):
                 overrides.get("retry_on_status", self._cfg.retry_on_status),
             )
             for tool_name, overrides in self._cfg.tool_overrides.items()
+        }
+
+    def to_rust_native_policy(self, tool_name: str, ceiling: int) -> Optional[dict[str, Any]]:
+        raw_cfg = RetryConfig(**(self.config.config or {}))
+        cfg = _cfg_for(raw_cfg, tool_name)
+        if cfg.max_retries > ceiling:
+            cfg = cfg.model_copy(update={"max_retries": ceiling})
+
+        if cfg.check_text_content:
+            return None
+
+        return {
+            "kind": "retry_with_backoff",
+            "maxRetries": int(cfg.max_retries),
+            "backoffBaseMs": int(cfg.backoff_base_ms),
+            "maxBackoffMs": int(cfg.max_backoff_ms),
+            "retryOnStatus": list(cfg.retry_on_status),
+            "jitter": bool(cfg.jitter),
         }
 
     async def tool_post_invoke(

--- a/plugins/tests/retry_with_backoff/test_integration.py
+++ b/plugins/tests/retry_with_backoff/test_integration.py
@@ -164,6 +164,82 @@ class TestCfgFor:
         assert result.max_retries == 3
 
 
+class TestRustNativePolicy:
+    def test_simple_config_returns_wire_policy(self):
+        plugin = make_plugin(
+            {
+                "max_retries": 3,
+                "backoff_base_ms": 150,
+                "max_backoff_ms": 3000,
+                "retry_on_status": [500, 503],
+                "jitter": False,
+            }
+        )
+
+        assert plugin.to_rust_native_policy("tool_a", ceiling=10) == {
+            "kind": "retry_with_backoff",
+            "maxRetries": 3,
+            "backoffBaseMs": 150,
+            "maxBackoffMs": 3000,
+            "retryOnStatus": [500, 503],
+            "jitter": False,
+        }
+
+    def test_ceiling_clamps_max_retries(self):
+        plugin = make_plugin({"max_retries": 3})
+
+        policy = plugin.to_rust_native_policy("tool_a", ceiling=1)
+
+        assert policy is not None
+        assert policy["maxRetries"] == 1
+
+    def test_per_tool_override_is_merged(self):
+        plugin = make_plugin(
+            {
+                "max_retries": 3,
+                "backoff_base_ms": 200,
+                "max_backoff_ms": 5000,
+                "retry_on_status": [500],
+                "jitter": True,
+                "tool_overrides": {
+                    "slow_api": {
+                        "max_retries": 2,
+                        "backoff_base_ms": 750,
+                        "retry_on_status": [429, 503],
+                        "jitter": False,
+                    }
+                },
+            }
+        )
+
+        assert plugin.to_rust_native_policy("slow_api", ceiling=10) == {
+            "kind": "retry_with_backoff",
+            "maxRetries": 2,
+            "backoffBaseMs": 750,
+            "maxBackoffMs": 5000,
+            "retryOnStatus": [429, 503],
+            "jitter": False,
+        }
+
+    def test_per_tool_override_max_retries_is_clamped(self):
+        plugin = make_plugin(
+            {
+                "max_retries": 3,
+                "tool_overrides": {"slow_api": {"max_retries": 8}},
+            }
+        )
+
+        policy = plugin.to_rust_native_policy("slow_api", ceiling=2)
+
+        assert policy is not None
+        assert policy["maxRetries"] == 2
+
+    def test_check_text_content_returns_none(self):
+        plugin = make_plugin({"check_text_content": True})
+
+        assert plugin.to_rust_native_policy("tool_a", ceiling=10) is None
+
+
 class TestPluginInit:
     def test_max_retries_clamped_to_gateway_ceiling(self):
         with patch("cpex_retry_with_backoff.retry_with_backoff.get_settings") as mock_settings:

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2127,7 +2127,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("working-directory: plugins/rust/python-package/${{ matrix.plugin }}", workflow)
         self.assertIn("release-validation:", workflow)
         self.assertIn("uses: ./.github/workflows/release-rust-python-package.yaml", workflow)
-        self.assertIn("tag: retry-with-backoff-v0.1.1", workflow)
+        self.assertIn("tag: retry-with-backoff-v0.2.0", workflow)
         self.assertIn("repository: testpypi", workflow)
         self.assertIn("publish_enabled: false", workflow)
         self.assertNotIn("tools/plugin_catalog.py ci-selection-field", workflow)
@@ -2438,6 +2438,42 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertEqual(payload["plugins"]["alpha"]["line_rate"], 50.0)
             self.assertEqual(payload["plugins"]["beta"]["line_rate"], 75.0)
 
+    def test_coverage_check_accepts_windows_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/alpha"]\n'
+                '[workspace.package]\nrepository = "https://github.com/IBM/cpex-plugins"\n'
+            )
+            self._create_plugin(root, "alpha")
+            report = root / "coverage.xml"
+            report.write_text(
+                textwrap.dedent(
+                    r"""
+                    <coverage>
+                      <packages>
+                        <package name="plugins.rust.python-package.alpha.src">
+                          <classes>
+                            <class filename="D:\a\cpex-plugins\cpex-plugins\plugins\rust\python-package\alpha\src\lib.rs">
+                              <lines>
+                                <line number="1" hits="1"/>
+                                <line number="2" hits="0"/>
+                              </lines>
+                            </class>
+                          </classes>
+                        </package>
+                      </packages>
+                    </coverage>
+                    """
+                ).strip()
+            )
+
+            result = run_catalog("coverage-check", str(root), str(report), "50.0", '["alpha"]')
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["plugins"]["alpha"]["line_rate"], 50.0)
+
     def test_coverage_check_rejects_plugin_with_no_counted_lines(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -2683,7 +2719,10 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn('"${tmpdir}/tests/${{ needs.resolve.outputs.slug }}" -v', workflow)
         self.assertNotIn('PYTHONPATH="${GITHUB_WORKSPACE}/${{ needs.resolve.outputs.plugin_path }}/tests"', workflow)
         self.assertEqual(workflow.count("cargo run --bin stub_gen"), 1)
-        self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)
+        self.assertIn('git ls-remote --exit-code --tags origin "refs/tags/${tag}"', workflow)
+        self.assertIn('elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" && "${PUBLISH_ENABLED}" == "false" ]]; then', workflow)
+        self.assertIn('checkout_ref="${GITHUB_SHA}"', workflow)
+        self.assertIn('echo "Release tag ${tag} does not exist" >&2', workflow)
         self.assertIn("python3 tools/plugin_catalog.py release-info .", workflow)
         self.assertIn('if [[ -n "${TAG_INPUT}" ]]; then', workflow)
         self.assertIn("workflow_call:", workflow)
@@ -2692,6 +2731,10 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn('git fetch --force origin "refs/heads/main:refs/remotes/origin/main"', workflow)
         self.assertIn('if git merge-base --is-ancestor "${tag_ref}" "refs/remotes/origin/main"; then', workflow)
         self.assertIn("tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}", workflow)
+        self.assertIn("slug: ${{ steps.resolve.outputs.plugin }}", workflow)
+        self.assertIn("publish_enabled: ${{ steps.resolve.outputs.publish_enabled }}", workflow)
+        self.assertIn('echo "publish_enabled=false"', workflow)
+        self.assertIn('echo "publish_enabled=true"', workflow)
         self.assertIn(
             'wheel_matrix="$(python3 -c \'import json; print(json.dumps([{',
             workflow,
@@ -2713,7 +2756,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("runs-on: ${{ matrix.runner }}", workflow)
         self.assertIn("name: wheel-${{ matrix.platform }}", workflow)
         self.assertIn(
-            "if: ${{ (github.event_name != 'workflow_call' || inputs.publish_enabled) && (needs.resolve.outputs.publish_env != 'pypi' || needs.resolve.outputs.tag_on_main == 'true') }}",
+            "if: ${{ needs.resolve.outputs.publish_enabled == 'true' && (needs.resolve.outputs.publish_env != 'pypi' || needs.resolve.outputs.tag_on_main == 'true') }}",
             workflow,
         )
         self.assertNotIn("matrix.", preflight_section)
@@ -2949,6 +2992,19 @@ class PluginCatalogTests(unittest.TestCase):
         makefile = (REPO_ROOT / "Makefile").read_text()
         self.assertIn("make ci", makefile)
         self.assertNotIn("make install && make test-all", makefile)
+
+    def test_retry_make_ci_enforces_local_coverage_floor(self) -> None:
+        plugin_dir = REPO_ROOT / "plugins" / "rust" / "python-package" / "retry_with_backoff"
+        makefile = (plugin_dir / "Makefile").read_text()
+        self.assertIn("ci: ci-build test-integration coverage", makefile)
+        self.assertIn("rustup component add llvm-tools-preview", makefile)
+        self.assertIn("cargo install cargo-llvm-cov --version $(CARGO_LLVM_COV_VERSION) --locked", makefile)
+        self.assertIn("cargo llvm-cov clean --workspace", makefile)
+        self.assertIn("cargo llvm-cov report -p $(CARGO_PACKAGE)", makefile)
+        self.assertIn(
+            "python3 $(REPO_ROOT)/tools/plugin_catalog.py coverage-check $(REPO_ROOT) $(COVERAGE_REPORT) $(COVERAGE_MIN)",
+            makefile,
+        )
 
     def test_secrets_detection_keeps_scanner_module_internal(self) -> None:
         lib_rs = (

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -389,7 +389,7 @@ def validate_plugin_dir(
     package = cargo.get("package", {})
     if not isinstance(package, dict):
         raise CatalogError(f"{plugin_dir}: Cargo.toml [package] must be a table")
-    relative_plugin_path = str(plugin_dir.relative_to(root))
+    relative_plugin_path = plugin_dir.relative_to(root).as_posix()
 
     if relative_plugin_path not in workspace_members:
         raise CatalogError(
@@ -565,10 +565,13 @@ def coverage_check(
     plugin_lines: dict[str, dict[str, int]] = {}
     prefix = MANAGED_ROOT.as_posix() + "/"
     for class_node in coverage.findall(".//class"):
-        filename = class_node.attrib.get("filename", "")
-        if not filename.startswith(prefix):
+        filename = class_node.attrib.get("filename", "").replace("\\", "/")
+        if filename.startswith(prefix):
+            relative = filename[len(prefix) :]
+        elif f"/{prefix}" in filename:
+            relative = filename.split(f"/{prefix}", maxsplit=1)[1]
+        else:
             continue
-        relative = filename[len(prefix) :]
         slug = relative.split("/", maxsplit=1)[0]
         counts = plugin_lines.setdefault(slug, {"covered_lines": 0, "valid_lines": 0})
         for line_node in class_node.findall("./lines/line"):


### PR DESCRIPTION
## Summary
- Add `RetryWithBackoffPlugin.to_rust_native_policy()` for the Rust native retry policy wire contract.
- Cover the new native policy behavior in the existing retry integration test file.
- Bump `cpex-retry-with-backoff` to `0.2.0` for the new feature.
- Make retry `make ci` enforce the same 90% Rust coverage floor locally.

## Scope
This PR is scoped to the retry_with_backoff native policy feature, its version bump, focused tests, and local CI coverage enforcement. It does not change release workflows, CI workflow tags, or test layout.

## Validation
- `make ci` from `plugins/rust/python-package/retry_with_backoff`

## Notes
PR for issue #21.
