### PR TITLE
Fix release artifact test selection

### DIFF
--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -197,10 +197,10 @@ jobs:
           if [[ ! -f "${venv_python}" ]]; then
             venv_python="${tmpdir}/venv/Scripts/python.exe"
           fi
-          "${venv_python}" -m pip install dist/*.whl pytest pytest-asyncio PyYAML
-          if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" ]]; then
+          "${venv_python}" -m pip install dist/*.whl pytest pytest-asyncio pydantic PyYAML
+          if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" ]]; then
             mkdir -p "${tmpdir}/tests"
-            cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" "${tmpdir}/tests/${{ needs.resolve.outputs.slug }}"
+            cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" "${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}"
             cp "${GITHUB_WORKSPACE}/plugins/tests/conftest.py" "${tmpdir}/tests/conftest.py"
             cp "${GITHUB_WORKSPACE}/plugins/tests/plugin_hooks.py" "${tmpdir}/tests/plugin_hooks.py"
             cp "${GITHUB_WORKSPACE}/plugins/tests/pytest.ini" "${tmpdir}/pytest.ini"
@@ -209,7 +209,7 @@ jobs:
             export PYTHONPATH="${tmpdir}/tests"
             "${venv_python}" -m pytest \
               -c "${tmpdir}/pytest.ini" \
-              "${tmpdir}/tests/${{ needs.resolve.outputs.slug }}" -v
+              "${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}" -v
           fi
 
   build-sdist:
@@ -249,10 +249,10 @@ jobs:
           if [[ ! -f "${venv_python}" ]]; then
             venv_python="${tmpdir}/venv/Scripts/python.exe"
           fi
-          "${venv_python}" -m pip install dist/*.tar.gz pytest pytest-asyncio PyYAML
-          if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" ]]; then
+          "${venv_python}" -m pip install dist/*.tar.gz pytest pytest-asyncio pydantic PyYAML
+          if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" ]]; then
             mkdir -p "${tmpdir}/tests"
-            cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" "${tmpdir}/tests/${{ needs.resolve.outputs.slug }}"
+            cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" "${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}"
             cp "${GITHUB_WORKSPACE}/plugins/tests/conftest.py" "${tmpdir}/tests/conftest.py"
             cp "${GITHUB_WORKSPACE}/plugins/tests/plugin_hooks.py" "${tmpdir}/tests/plugin_hooks.py"
             cp "${GITHUB_WORKSPACE}/plugins/tests/pytest.ini" "${tmpdir}/pytest.ini"
@@ -261,7 +261,7 @@ jobs:
             export PYTHONPATH="${tmpdir}/tests"
             "${venv_python}" -m pytest \
               -c "${tmpdir}/pytest.ini" \
-              "${tmpdir}/tests/${{ needs.resolve.outputs.slug }}" -v
+              "${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}" -v
           fi
 
   publish:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@
 This is a monorepo of standalone plugin packages for the ContextForge Plugin Extensibility (CPEX) Framework. Each plugin lives in its own top-level directory with independent build configuration.
 
 - Plugins are Rust+Python (PyO3/maturin) or pure Python.
-- Each plugin has its own `pyproject.toml`, `Cargo.toml`, `Makefile`, and `tests/`.
+- Each plugin has its own `pyproject.toml`, `Cargo.toml`, and `Makefile`.
+- Python integration tests live under `plugins/tests/<slug>/`; Rust unit tests live in the plugin crate.
 - Package names follow the pattern `cpex-<plugin-name>` (e.g., `cpex-rate-limiter`).
 - `mcpgateway` is a runtime dependency provided by the host gateway — never declare it in `pyproject.toml`.
 

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2667,20 +2667,21 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("rustc --version", workflow)
         self.assertIn("working-directory: ${{ needs.resolve.outputs.plugin_path }}", workflow)
         self.assertIn(
-            'if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" ]]; then',
+            'if [[ -d "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" ]]; then',
             workflow,
         )
         self.assertIn(
-            'cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.slug }}" "${tmpdir}/tests/${{ needs.resolve.outputs.slug }}"',
+            'cp -R "${GITHUB_WORKSPACE}/plugins/tests/${{ needs.resolve.outputs.plugin }}" "${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}"',
             workflow,
         )
+        self.assertIn("pytest pytest-asyncio pydantic PyYAML", workflow)
         self.assertIn('cp "${GITHUB_WORKSPACE}/plugins/tests/conftest.py"', workflow)
         self.assertIn('cp "${GITHUB_WORKSPACE}/plugins/tests/plugin_hooks.py"', workflow)
         self.assertIn('cp "${GITHUB_WORKSPACE}/plugins/tests/pytest.ini"', workflow)
         self.assertIn("CPEX_TEST_PLUGIN_HOOKS=1", workflow)
         self.assertIn('PYTHONPATH="${tmpdir}/tests"', workflow)
         self.assertIn('cd "${tmpdir}"', workflow)
-        self.assertIn('"${tmpdir}/tests/${{ needs.resolve.outputs.slug }}" -v', workflow)
+        self.assertIn('"${tmpdir}/tests/${{ needs.resolve.outputs.plugin }}" -v', workflow)
         self.assertNotIn('PYTHONPATH="${GITHUB_WORKSPACE}/${{ needs.resolve.outputs.plugin_path }}/tests"', workflow)
         self.assertEqual(workflow.count("cargo run --bin stub_gen"), 1)
         self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)


### PR DESCRIPTION
## Summary
- use the resolved plugin output for release artifact integration tests
- install pydantic in isolated artifact test environments for secrets detection tests
- update repo guidance for the repo-level integration test layout

## Verification
- python3 -m unittest tests/test_plugin_catalog.py tests/test_install_built_wheel.py
- python3 tools/plugin_catalog.py validate .
- git diff --check origin/main..HEAD