### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci-install-built-wheel.yaml
+++ b/.github/workflows/ci-install-built-wheel.yaml
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-plugin-catalog.yaml
+++ b/.github/workflows/ci-plugin-catalog.yaml
@@ -29,9 +29,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -52,11 +52,11 @@ jobs:
       plugin_count: ${{ steps.detect.outputs.plugin_count }}
       cargo_packages: ${{ steps.detect.outputs.cargo_packages }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -104,9 +104,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -137,7 +137,7 @@ jobs:
     if: needs.validate-and-detect.outputs.has_plugins == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Verify Rust toolchain
         run: |
@@ -158,9 +158,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -220,7 +220,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Verify Rust toolchain
         run: |

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -206,7 +206,7 @@ jobs:
         run: python3 tools/plugin_catalog.py coverage-check . coverage/cobertura.xml 90.00 "${PLUGINS}"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
         with:
           files: ./coverage/cobertura.xml
           flags: rust-python-package-workspace

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -199,7 +199,7 @@ jobs:
         run: uv run maturin build --release --out dist
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: wheel-${{ matrix.platform }}
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.whl
@@ -251,7 +251,7 @@ jobs:
         run: uv run maturin sdist --out dist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: sdist
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.tar.gz
@@ -289,7 +289,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -50,9 +50,9 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -130,11 +130,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
@@ -162,11 +162,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
@@ -235,11 +235,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2140,11 +2140,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("uv==0.9.30", workflow)
         self.assertIn("maturin==1.12.6", workflow)
         self.assertIn(
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
             workflow,
         )
         self.assertNotIn("actions/checkout@v4", workflow)
@@ -2165,11 +2165,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn("tests/test_install_built_wheel.py", workflow)
         self.assertNotIn("python3 tools/plugin_catalog.py ci-selection", workflow)
         self.assertIn(
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
             workflow,
         )
 
@@ -2185,11 +2185,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("uses: ./.github/workflows/release-rust-python-package.yaml", workflow)
         self.assertIn("publish_enabled: false", workflow)
         self.assertIn(
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
             workflow,
         )
 
@@ -2794,19 +2794,19 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn('"${venv_python}" -m pip install', workflow)
         self.assertIn('"${venv_python}" -m pytest', workflow)
         self.assertIn(
-            "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
             workflow,
         )
         self.assertIn(
-            "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+            "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
             workflow,
         )
         self.assertIn(
-            "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
             workflow,
         )
         self.assertLess(


### PR DESCRIPTION
## Summary

- Update pinned `actions/checkout` references to the Node 24-based `v6.0.2` commit.
- Update pinned `actions/setup-python` references to the Node 24-based `v6.2.0` commit.
- Update remaining pinned workflow actions that still used Node 20: Codecov, upload-artifact, and download-artifact.
- Keep workflow action references SHA-pinned while removing Node.js 20 deprecation warnings.

## Major-Version Review Notes

- `actions/checkout` release notes reviewed for `v5.0.0`, `v6.0.0`, and `v6.0.2`. The workflows do not configure sparse checkout, and the existing `fetch-depth: 0` usage is preserved unchanged in `ci-rust-python-package.yaml`. The PR CI `validate-and-detect` job has passed with this setting.
- `actions/setup-python` release notes reviewed for `v5.0.0`, `v6.0.0`, and `v6.2.0`. The workflows use setup-python only to install Python 3.12 before invoking `pip`, `uv`, and `maturin`; they do not rely on setup-python cache behavior or virtualenv activation. The plugin catalog and install-built-wheel checks have passed after the upgrade.
- `codecov/codecov-action` now resolves to a composite action. This is a no-op for this repo's usage because the workflow only uploads one generated Cobertura XML file with explicit `files`, `flags`, and `name` inputs.

## SHA Provenance

- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` -> [`v6.0.2`](https://github.com/actions/checkout/releases/tag/v6.0.2)
- `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` -> [`v6.2.0`](https://github.com/actions/setup-python/releases/tag/v6.2.0)
- `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` -> [`v5.5.4`](https://github.com/codecov/codecov-action/releases/tag/v5.5.4) peeled commit from annotated tag `aa56896cf108bd10b5eb883cd1d24196da57f695`
- `actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f` -> [`v6.0.0`](https://github.com/actions/upload-artifact/releases/tag/v6.0.0)
- `actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131` -> [`v7.0.0`](https://github.com/actions/download-artifact/releases/tag/v7.0.0)

## Validation

- `git diff --check HEAD~1..HEAD`
- `ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }; puts "parsed workflow YAML files"' .github/workflows/*.yaml`
- `actionlint .github/workflows/*.yaml`
- `python3 -m unittest tests/test_plugin_catalog.py` -> 91 tests passed, 2 skipped
- Metadata scan of all external workflow actions confirms no `runs.using: node20` remains:
  - `actions/checkout` -> `node24`
  - `actions/setup-python` -> `node24`
  - `actions/upload-artifact` -> `node24`
  - `actions/download-artifact` -> `node24`
  - `codecov/codecov-action` -> `composite`
  - `pypa/gh-action-pypi-publish` -> `composite`

Note: Standard detailed code review has not been run yet.
