### PR TITLE
fix(rate-limiter): production hardening — TLS support for managed Redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,17 +57,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -907,9 +896,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordered-float"
@@ -1364,32 +1353,28 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+checksum = "014cc767fefab6a3e798ca45112bccad9c6e0e218fbd49720042716c73cfef44"
 dependencies = [
- "arc-swap",
- "async-trait",
  "bytes",
+ "cfg-if",
  "combine",
  "futures-util",
- "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
- "rustls-pki-types",
  "ryu",
  "sha1_smol",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1474,7 +1459,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1483,24 +1467,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -1632,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1761,16 +1735,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -1923,7 +1887,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2302,15 +2266,6 @@ checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,6 +906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,12 +1378,18 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "ryu",
  "sha1_smol",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1420,6 +1442,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1466,62 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustpython-ast"
@@ -1510,6 +1602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1628,29 @@ dependencies = [
  "pyo3-stub-gen",
  "regex",
  "serde_json",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1671,6 +1795,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1937,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1985,6 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2302,24 @@ checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2499,6 +2663,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "pyo3-log",
  "pyo3-stub-gen",
  "redis",
+ "rustls",
  "thiserror",
  "tokio",
 ]
@@ -1374,7 +1375,6 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "url",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1459,6 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2266,15 +2267,6 @@ checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "rate_limiter"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/deny.toml
+++ b/deny.toml
@@ -63,7 +63,6 @@ allow = [
     "CC0-1.0",
     "CDDL-1.0",
     "CDDL-1.1",
-    "CDLA-Permissive-2.0",
     "ClArtistic",
     "CPL-1.0",
     "curl",

--- a/deny.toml
+++ b/deny.toml
@@ -63,6 +63,7 @@ allow = [
     "CC0-1.0",
     "CDDL-1.0",
     "CDDL-1.1",
+    "CDLA-Permissive-2.0",
     "ClArtistic",
     "CPL-1.0",
     "curl",

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -24,7 +24,7 @@ pyo3-stub-gen = { workspace = true }
 pyo3-log = { workspace = true }
 parking_lot = "0.12"
 thiserror = { workspace = true }
-redis = { version = "0.27", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-webpki-roots", "tokio-rustls-comp"] }
+redis = { version = "0.32", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-webpki-roots", "tokio-rustls-comp"] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -24,7 +24,21 @@ pyo3-stub-gen = { workspace = true }
 pyo3-log = { workspace = true }
 parking_lot = "0.12"
 thiserror = { workspace = true }
-redis = { version = "0.32", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-webpki-roots", "tokio-rustls-comp"] }
+redis = { version = "0.32", features = ["aio", "tokio-comp", "tls-rustls", "tokio-rustls-comp"] }
+# Direct rustls dep with the `ring` crypto provider feature. redis 0.32
+# pulls rustls in transitively but via `default-features = false`, so no
+# crypto provider is enabled by default — rustls 0.23 then panics at
+# first TLS use ("Call CryptoProvider::install_default()..."). We add
+# `ring` here and install it as the default provider once at plugin init.
+#
+# Note on CA roots: by NOT enabling `tls-rustls-webpki-roots`, the redis
+# crate falls back to `rustls-native-certs` (Apache-2.0 / MIT / ISC) which
+# reads CA certificates from the host OS trust store at runtime. This
+# avoids a transitive dep on `webpki-roots` (CDLA-Permissive-2.0). The
+# trade-off: the host container must have a CA bundle installed — true
+# for the UBI Minimal image mcp-context-forge ships on, and for any
+# distribution that keeps `ca-certificates` in its base.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rate_limiter"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -24,7 +24,7 @@ pyo3-stub-gen = { workspace = true }
 pyo3-log = { workspace = true }
 parking_lot = "0.12"
 thiserror = { workspace = true }
-redis = { version = "0.27", features = ["aio", "tokio-comp"] }
+redis = { version = "0.27", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-webpki-roots", "tokio-rustls-comp"] }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Contributors"
-version: "0.0.5"
+version: "0.0.6"
 kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/rate_limiter/src/plugin.rs
+++ b/plugins/rust/python-package/rate_limiter/src/plugin.rs
@@ -540,8 +540,28 @@ fn log_exception(py: Python<'_>, message: &str) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::await_async_tuple;
+    use super::ensure_crypto_provider;
     use pyo3::prelude::*;
     use pyo3::types::{PyAnyMethods, PyDictMethods, PyModule};
+
+    #[test]
+    fn ensure_crypto_provider_installs_a_default() {
+        // Mutation guard: cargo-mutants tries replacing the body of
+        // `ensure_crypto_provider` with `()`. Under that mutation no rustls
+        // crypto provider is installed by us, and (since no other code path
+        // in this crate installs one) `CryptoProvider::get_default()` returns
+        // None — surfacing the wo-tracker #68217 runtime-time signature
+        // ("Call CryptoProvider::install_default() before this point...")
+        // the function exists to prevent.
+        //
+        // OnceLock makes the call idempotent; this test is safe to run in
+        // any order alongside other tests in the same process.
+        ensure_crypto_provider();
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "ensure_crypto_provider() must leave a default rustls crypto provider installed",
+        );
+    }
 
     #[test]
     fn await_async_tuple_parses_successful_result() -> PyResult<()> {

--- a/plugins/rust/python-package/rate_limiter/src/plugin.rs
+++ b/plugins/rust/python-package/rate_limiter/src/plugin.rs
@@ -4,7 +4,7 @@
 // Rust-owned rate limiter plugin core. Python only keeps a tiny compatibility
 // shell so the gateway can continue importing a `Plugin` subclass.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use cpex_framework_bridge::{build_framework_object, default_result};
 use log::warn;
@@ -16,6 +16,24 @@ use pyo3_stub_gen::derive::*;
 use crate::engine::RateLimiterEngine;
 
 const LOGGER_NAME: &str = "cpex_rate_limiter.rate_limiter";
+
+/// Process-global guard: installs the rustls ring crypto provider exactly
+/// once. rustls 0.23 dropped its implicit default crypto provider, so any
+/// caller that wants TLS must install one before first use. The redis
+/// crate's `tls-rustls` feature does not pick a provider, so without this
+/// the first `rediss://` operation panics with
+/// "Call CryptoProvider::install_default() before this point...".
+///
+/// `install_default` returns Err if a provider is already installed (e.g.
+/// by another caller in the same process); that's a no-op for us, so we
+/// discard the result.
+static CRYPTO_PROVIDER_INSTALLED: OnceLock<()> = OnceLock::new();
+
+fn ensure_crypto_provider() {
+    CRYPTO_PROVIDER_INSTALLED.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
 
 #[gen_stub_pyclass]
 #[pyclass]
@@ -33,6 +51,10 @@ pub struct RateLimiterPluginCore {
 impl RateLimiterPluginCore {
     #[new]
     pub fn new(config: &Bound<'_, PyDict>) -> PyResult<Self> {
+        // Install the rustls crypto provider before any redis client is
+        // constructed — required for `rediss://` URLs to work past the
+        // first TLS handshake. See `ensure_crypto_provider` doc above.
+        ensure_crypto_provider();
         let engine = Arc::new(RateLimiterEngine::new(config)?);
         let fail_closed = parse_fail_mode(config)?;
         Ok(Self {

--- a/plugins/rust/python-package/rate_limiter/src/plugin.rs
+++ b/plugins/rust/python-package/rate_limiter/src/plugin.rs
@@ -550,7 +550,7 @@ mod tests {
         // `ensure_crypto_provider` with `()`. Under that mutation no rustls
         // crypto provider is installed by us, and (since no other code path
         // in this crate installs one) `CryptoProvider::get_default()` returns
-        // None — surfacing the wo-tracker #68217 runtime-time signature
+        // None — surfacing the runtime-time signature
         // ("Call CryptoProvider::install_default() before this point...")
         // the function exists to prevent.
         //

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1578,3 +1578,42 @@ class TestConfigHardening:
             "engine must warn on unknown config keys so misspellings are visible — "
             f"captured records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
         )
+
+
+class TestRedisTlsSupport:
+    """TLS / rediss:// scheme support.
+
+    Regression coverage for wo-tracker #68217: managed Redis services
+    (AWS ElastiCache with in-transit encryption, Redis Cloud, etc.) require
+    a `rediss://` URL. The Rust engine must be built with the redis crate's
+    TLS feature so that constructing a client with a `rediss://` URL parses
+    successfully — without it the engine raises `InvalidClientConfig: can't
+    connect with TLS, the feature is not enabled` at plugin init and the
+    plugin is silently skipped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rediss_url_does_not_fail_with_tls_not_enabled(self):
+        """Constructing the plugin with a rediss:// URL must not raise InvalidClientConfig.
+
+        Construction is independent of connectivity: the redis crate parses
+        the URL and creates a lazy client. We point at a port nothing is
+        listening on so the test never opens a real TLS handshake.
+        """
+        # rediss:// = TLS scheme. Port 1 has no listener; we never attempt
+        # a real connection here — the regression is at URL/feature parsing.
+        plugin = RateLimiterPlugin(
+            PluginConfig(
+                name="RateLimiter",
+                kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
+                hooks=["tool_pre_invoke"],
+                priority=100,
+                config={
+                    "by_user": "3/s",
+                    "backend": "redis",
+                    "redis_url": "rediss://127.0.0.1:1/15",
+                    "algorithm": "fixed_window",
+                },
+            )
+        )
+        assert plugin is not None

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1684,3 +1684,319 @@ class TestRedisTlsSupport:
         )
 
 
+# =============================================================================
+# Real TLS Redis handshake test
+# =============================================================================
+# The TestRedisTlsSupport class above only verifies that the redis crate was
+# compiled with TLS support and that the wo-tracker #68217 InvalidClientConfig
+# signature does not appear — neither test drives a real TLS handshake.
+# A handshake regression (missing crypto provider, bad cert chain, broken
+# rustls-native-certs lookup) could pass those tests while failing in
+# production.
+#
+# This fixture spins up a Redis container listening on TLS only, behind a
+# self-signed CA generated fresh in /tmp.  SSL_CERT_FILE is exported so both
+# rustls-native-certs (the Rust core's TLS path) and Python's ssl module
+# (test-side helpers) trust the test CA without touching the OS trust store.
+# The container is module-scoped and torn down on teardown.
+#
+# The whole stack skips cleanly when openssl or docker are unavailable, so
+# laptops without docker stay green while Linux CI runners exercise the full
+# end-to-end path.
+# =============================================================================
+
+
+_TEST_TLS_REDIS_CONTAINER_PORT = 16390
+_TEST_TLS_REDIS_CONTAINER_NAME = "pytest-rl-redis-tls-integ"
+
+
+def _openssl_available() -> bool:
+    """Return True if the openssl CLI is on PATH."""
+    try:
+        result = subprocess.run(
+            ["openssl", "version"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _docker_available() -> bool:
+    """Return True if the docker CLI is on PATH and the daemon is reachable."""
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _generate_self_signed_redis_cert(cert_dir: str) -> tuple[str, str, str]:
+    """Generate a self-signed CA and a Redis server cert in cert_dir.
+
+    Mirrors mcp-context-forge/tls-test/gen-certs.sh but with a 1-day TTL
+    (long enough to never expire mid-test, short enough to make leakage
+    obvious) and 2048-bit RSA (faster than 4096; ephemeral test material
+    only).  Returns (ca.crt, redis.crt, redis.key) as absolute paths.
+    """
+    ca_key = os.path.join(cert_dir, "ca.key")
+    ca_crt = os.path.join(cert_dir, "ca.crt")
+    redis_key = os.path.join(cert_dir, "redis.key")
+    redis_crt = os.path.join(cert_dir, "redis.crt")
+    redis_csr = os.path.join(cert_dir, "redis.csr")
+    redis_ext = os.path.join(cert_dir, "redis.ext")
+
+    def _ssl(*args: str) -> None:
+        subprocess.run(
+            ["openssl", *args],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+    # Self-signed CA.  -addext is required for OpenSSL 3.x clients,
+    # which refuse to verify chains where the CA cert lacks an
+    # explicit keyUsage extension ("CA cert does not include key
+    # usage extension").  Older clients ignore the extra extensions.
+    _ssl("genrsa", "-out", ca_key, "2048")
+    _ssl(
+        "req", "-x509", "-new", "-nodes",
+        "-key", ca_key, "-sha256", "-days", "1",
+        "-subj", "/CN=cpex-pytest-tls-ca",
+        "-addext", "basicConstraints=critical,CA:true",
+        "-addext", "keyUsage=critical,keyCertSign,cRLSign",
+        "-out", ca_crt,
+    )
+
+    # Redis server cert signed by the CA.  SAN covers localhost +
+    # 127.0.0.1 so both the in-test PING and the plugin's connection
+    # to the host-mapped port verify cleanly.
+    _ssl("genrsa", "-out", redis_key, "2048")
+    _ssl("req", "-new", "-key", redis_key, "-subj", "/CN=localhost", "-out", redis_csr)
+    with open(redis_ext, "w") as f:
+        f.write("subjectAltName = DNS:localhost,IP:127.0.0.1\nextendedKeyUsage = serverAuth\n")
+    _ssl(
+        "x509", "-req", "-in", redis_csr,
+        "-CA", ca_crt, "-CAkey", ca_key, "-CAcreateserial",
+        "-out", redis_crt, "-days", "1", "-sha256",
+        "-extfile", redis_ext,
+    )
+
+    # Permissions: world-readable cert/key files so the redis user
+    # inside the container (typically UID 999) can read them through
+    # the bind mount; keys are still locked down to the file owner
+    # for write.
+    for p in (ca_crt, redis_crt, redis_key):
+        os.chmod(p, 0o644)
+
+    return ca_crt, redis_crt, redis_key
+
+
+def _tls_redis_pings(host: str, port: int, ca_crt: str, timeout: float = 1.0) -> bool:
+    """Return True if a TLS PING to host:port verifies against ca_crt and returns PONG."""
+    try:
+        # Third-Party
+        import redis as _redis_sync  # noqa: PLC0415
+    except Exception:
+        return False
+    try:
+        client = _redis_sync.Redis(
+            host=host,
+            port=port,
+            ssl=True,
+            ssl_ca_certs=ca_crt,
+            socket_connect_timeout=timeout,
+            socket_timeout=timeout,
+        )
+        try:
+            return bool(client.ping())
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def redis_tls_url_for_integration():
+    """Yield a rediss:// URL backed by a real TLS-enabled Redis container.
+
+    Closes the gap left by TestRedisTlsSupport (which is construction-only).
+    Generates a fresh self-signed CA + Redis cert in /tmp, starts a
+    redis:7 container with --tls-port 6390 (host port 16390), and exports
+    SSL_CERT_FILE so both rustls-native-certs (Rust core) and Python's
+    ssl module (test-side helpers) pick up the test CA.
+
+    Skips cleanly if openssl or docker is unavailable.  An external
+    operator can short-circuit the cert/container setup by exporting
+    RATE_LIMITER_TLS_REDIS_URL=rediss://<host>:<port>/15 with a CA the
+    current process already trusts.
+    """
+    override = os.environ.get("RATE_LIMITER_TLS_REDIS_URL")
+    if override:
+        # Caller-managed endpoint and trust store; we leave SSL_CERT_FILE alone.
+        yield override
+        return
+
+    try:
+        # Third-Party
+        import redis.asyncio  # noqa: F401, PLC0415
+    except Exception:
+        pytest.skip("redis.asyncio package not installed")
+
+    if not _openssl_available():
+        pytest.skip("openssl CLI not available; skipping real TLS handshake test")
+    if not _docker_available():
+        pytest.skip("docker not available; skipping real TLS handshake test")
+
+    # The cert dir has two constraints: pytest's tmp_path_factory parents
+    # are mode 0700 (the redis container's UID 999 cannot traverse them),
+    # and /tmp is not always shared into the container runtime VM
+    # (Docker Desktop / colima on macOS share $HOME but not /tmp). A
+    # subdir under $HOME satisfies both: traversable on Linux CI and
+    # bind-mountable on dev laptops.
+    # Standard
+    import shutil  # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
+
+    cache_root = os.path.join(os.path.expanduser("~"), ".cache", "cpex-pytest-tls")
+    os.makedirs(cache_root, exist_ok=True)
+    cert_dir = tempfile.mkdtemp(prefix="cpex-tls-redis-", dir=cache_root)
+    os.chmod(cert_dir, 0o755)
+
+    try:
+        ca_crt, _redis_crt, _redis_key = _generate_self_signed_redis_cert(cert_dir)
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(cert_dir, ignore_errors=True)
+        pytest.skip(f"openssl failed to generate test certs: {exc.stderr!r}")
+
+    # Trust the freshly minted CA via SSL_CERT_FILE.  Honored by both
+    # rustls-native-certs (Linux + macOS) and Python's ssl default
+    # context — no OS trust store modification needed.
+    prev_ssl_cert_file = os.environ.get("SSL_CERT_FILE")
+    os.environ["SSL_CERT_FILE"] = ca_crt
+
+    def _restore_env() -> None:
+        if prev_ssl_cert_file is None:
+            os.environ.pop("SSL_CERT_FILE", None)
+        else:
+            os.environ["SSL_CERT_FILE"] = prev_ssl_cert_file
+
+    host = _TEST_REDIS_HOST
+    port = _TEST_TLS_REDIS_CONTAINER_PORT
+    container_id = None
+
+    try:
+        res = subprocess.run(
+            [
+                "docker", "run", "-d", "--rm",
+                "-p", f"{port}:6390",
+                "-v", f"{cert_dir}:/certs:ro",
+                "--name", _TEST_TLS_REDIS_CONTAINER_NAME,
+                "redis:7",
+                "redis-server",
+                "--port", "0",                    # disable plain TCP
+                "--tls-port", "6390",
+                "--tls-cert-file", "/certs/redis.crt",
+                "--tls-key-file", "/certs/redis.key",
+                "--tls-ca-cert-file", "/certs/ca.crt",
+                "--tls-auth-clients", "no",       # no client-cert auth for the smoke test
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        container_id = res.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        _restore_env()
+        shutil.rmtree(cert_dir, ignore_errors=True)
+        pytest.skip(f"failed to start TLS Redis container: {exc.stderr!r}")
+
+    # Wait for the TLS handshake + PING to round-trip.  Same rationale
+    # as redis_url_for_integration — TCP comes up before the server is
+    # ready, only PING is dispositive.
+    ready = False
+    for _ in range(100):
+        if _tls_redis_pings(host, port, ca_crt):
+            ready = True
+            break
+        time.sleep(0.1)
+
+    if not ready:
+        subprocess.run(["docker", "stop", container_id], check=False)
+        _restore_env()
+        shutil.rmtree(cert_dir, ignore_errors=True)
+        pytest.skip("TLS Redis did not become ready in time")
+
+    try:
+        yield f"rediss://{host}:{port}/15"
+    finally:
+        subprocess.run(["docker", "stop", container_id], check=False)
+        _restore_env()
+        shutil.rmtree(cert_dir, ignore_errors=True)
+
+
+class TestRedisTlsHandshake:
+    """End-to-end rustls handshake against a real TLS-enabled Redis.
+
+    TestRedisTlsSupport asserts that the redis crate was compiled with TLS
+    and that the wo-tracker #68217 ``InvalidClientConfig`` signature stays
+    absent — but nothing in that class drives a real handshake.  A
+    regression in the rustls crypto provider, the cert-chain loader, or
+    rustls-native-certs lookup could pass those tests yet fail at first
+    contact with a real TLS server.  This class closes that gap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rediss_handshake_succeeds_against_real_tls_redis(
+        self, redis_tls_url_for_integration
+    ):
+        """A tool_pre_invoke through rediss:// must complete the rustls handshake and write counters.
+
+        The redis client is lazy: URL parsing succeeds and the client is
+        constructed without ever touching the network, so the TLS path
+        only engages on the first command.  Driving a real
+        ``tool_pre_invoke`` against the TLS Redis forces that lazy code
+        path through the rustls handshake, and asserting that the
+        counter key materializes in the TLS Redis is the strongest
+        end-to-end signal the handshake completed: nothing else gets
+        you a written key.
+        """
+        await _flush_redis(redis_tls_url_for_integration)
+
+        plugin = _make_redis_plugin(redis_tls_url_for_integration, limit="3/s")
+        ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
+        payload = ToolPreInvokePayload(name="tool", arguments={})
+
+        result = await plugin.tool_pre_invoke(payload, ctx)
+
+        # First call under a 3/s limit must pass.  If the handshake had
+        # failed the Rust core would log the error and fail-mode-open
+        # would still let the request through — so we follow up with a
+        # key-in-Redis assertion below, which only succeeds if the
+        # backend was actually written to.
+        assert result.continue_processing is True, (
+            f"first request under 3/s must pass; got {result!r}"
+        )
+
+        # End-to-end proof of a successful handshake:
+        #   plugin -> Rust core -> redis crate -> rustls handshake ->
+        #   TLS Redis -> INCR -> key persists.
+        keys = await _keys_in_redis(redis_tls_url_for_integration, "rl:*")
+        assert any("alice" in k for k in keys), (
+            "expected a counter key for user 'alice' to appear in TLS Redis "
+            f"after a successful rustls handshake; got keys={keys!r}"
+        )
+

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1662,17 +1662,21 @@ class TestRedisTlsSupport:
             f"backend is unreachable; got result={result!r}"
         )
 
-        # The error logged must indicate connectivity failure (the lazy
-        # handshake reached the network and the network refused / timed out)
-        # — NOT the InvalidClientConfig shape that means rustls itself is
-        # not compiled in. The latter is the failure mode of wo-tracker
-        # #68217 and must never recur.
+        # Negative assertion — pins the wo-tracker #68217 regression.
+        #
+        # The original sev-1 fingerprint was rustls panicking at plugin init
+        # with `InvalidClientConfig: can't connect with TLS, the feature is
+        # not enabled`. After the redis crate is built with `tls-rustls` and
+        # the rustls crypto provider is installed, that signature must never
+        # appear again. This test asserts its absence.
+        #
+        # A positive "the lazy handshake reached the network" assertion
+        # would also be valuable — but the Rust core's log_exception()
+        # currently surfaces only a generic "error; allowing request"
+        # message, dropping the underlying redis::RedisError text. Surfacing
+        # those details requires a Rust core logging change; tracked as a
+        # follow-up alongside the real TLS Redis fixture work.
         all_messages = " ".join(r.getMessage() for r in caplog.records).lower()
-        assert "tls" not in all_messages or "connect" in all_messages or "refused" in all_messages or "timed out" in all_messages, (
-            "rediss:// failure must surface as a connectivity error, not a "
-            f"TLS feature/config error. Captured logs: "
-            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
-        )
         assert "feature is not enabled" not in all_messages and "invalidclientconfig" not in all_messages, (
             "rediss:// failure looks like the wo-tracker #68217 regression "
             f"(TLS feature not compiled). Captured logs: "

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1583,7 +1583,7 @@ class TestConfigHardening:
 class TestRedisTlsSupport:
     """TLS / rediss:// scheme support.
 
-    Regression coverage for wo-tracker #68217: managed Redis services
+    Regression coverage for managed Redis with in-transit encryption: managed Redis services
     (AWS ElastiCache with in-transit encryption, Redis Cloud, etc.) require
     a `rediss://` URL. The Rust engine must be built with the redis crate's
     TLS feature so that constructing a client with a `rediss://` URL parses
@@ -1631,7 +1631,7 @@ class TestRedisTlsSupport:
         the backend error; we assert the logged error is connectivity-shaped
         (refused / timed out / IO) rather than the unmistakable
         ``InvalidClientConfig: TLS feature not enabled`` shape that signaled
-        the original wo-tracker #68217 regression.
+        the original TLS-feature-not-enabled regression.
         """
         # Standard
         import logging  # noqa: PLC0415
@@ -1662,7 +1662,7 @@ class TestRedisTlsSupport:
             f"backend is unreachable; got result={result!r}"
         )
 
-        # Negative assertion — pins the wo-tracker #68217 regression.
+        # Negative assertion — pins the TLS-feature-not-enabled regression.
         #
         # The original sev-1 fingerprint was rustls panicking at plugin init
         # with `InvalidClientConfig: can't connect with TLS, the feature is
@@ -1678,7 +1678,7 @@ class TestRedisTlsSupport:
         # follow-up alongside the real TLS Redis fixture work.
         all_messages = " ".join(r.getMessage() for r in caplog.records).lower()
         assert "feature is not enabled" not in all_messages and "invalidclientconfig" not in all_messages, (
-            "rediss:// failure looks like the wo-tracker #68217 regression "
+            "rediss:// failure looks like the TLS-feature-not-enabled regression "
             f"(TLS feature not compiled). Captured logs: "
             f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
         )
@@ -1688,7 +1688,7 @@ class TestRedisTlsSupport:
 # Real TLS Redis handshake test
 # =============================================================================
 # The TestRedisTlsSupport class above only verifies that the redis crate was
-# compiled with TLS support and that the wo-tracker #68217 InvalidClientConfig
+# compiled with TLS support and that the InvalidClientConfig
 # signature does not appear — neither test drives a real TLS handshake.
 # A handshake regression (missing crypto provider, bad cert chain, broken
 # rustls-native-certs lookup) could pass those tests while failing in
@@ -1952,7 +1952,7 @@ class TestRedisTlsHandshake:
     """End-to-end rustls handshake against a real TLS-enabled Redis.
 
     TestRedisTlsSupport asserts that the redis crate was compiled with TLS
-    and that the wo-tracker #68217 ``InvalidClientConfig`` signature stays
+    and that the ``InvalidClientConfig`` signature stays
     absent — but nothing in that class drives a real handshake.  A
     regression in the rustls crypto provider, the cert-chain loader, or
     rustls-native-certs lookup could pass those tests yet fail at first

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1617,3 +1617,66 @@ class TestRedisTlsSupport:
             )
         )
         assert plugin is not None
+
+    @pytest.mark.asyncio
+    async def test_rediss_url_lazy_handshake_reaches_connectivity_layer(self, caplog):
+        """Lazy TLS path must fail as connectivity, not as a TLS-feature error.
+
+        Construction-only tests can pass even if the TLS feature compiled
+        in but the rustls handshake itself is broken — the redis crate parses
+        the URL fine and the client is created, but the first real operation
+        is where TLS actually engages. Driving ``tool_pre_invoke`` against a
+        rediss:// URL pointing at a closed port forces the client into that
+        lazy path. Default fail_mode=open allows the request after logging
+        the backend error; we assert the logged error is connectivity-shaped
+        (refused / timed out / IO) rather than the unmistakable
+        ``InvalidClientConfig: TLS feature not enabled`` shape that signaled
+        the original wo-tracker #68217 regression.
+        """
+        # Standard
+        import logging  # noqa: PLC0415
+
+        plugin = RateLimiterPlugin(
+            PluginConfig(
+                name="RateLimiter",
+                kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
+                hooks=["tool_pre_invoke"],
+                priority=100,
+                config={
+                    "by_user": "3/s",
+                    "backend": "redis",
+                    "redis_url": "rediss://127.0.0.1:1/15",
+                    "algorithm": "fixed_window",
+                },
+            )
+        )
+        ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
+        payload = ToolPreInvokePayload(name="tool", arguments={})
+
+        with caplog.at_level(logging.WARNING):
+            result = await plugin.tool_pre_invoke(payload, ctx)
+
+        # fail_mode=open default: the request is allowed when backend fails.
+        assert result.continue_processing is True, (
+            "Default fail_mode=open should allow the request when the rediss:// "
+            f"backend is unreachable; got result={result!r}"
+        )
+
+        # The error logged must indicate connectivity failure (the lazy
+        # handshake reached the network and the network refused / timed out)
+        # — NOT the InvalidClientConfig shape that means rustls itself is
+        # not compiled in. The latter is the failure mode of wo-tracker
+        # #68217 and must never recur.
+        all_messages = " ".join(r.getMessage() for r in caplog.records).lower()
+        assert "tls" not in all_messages or "connect" in all_messages or "refused" in all_messages or "timed out" in all_messages, (
+            "rediss:// failure must surface as a connectivity error, not a "
+            f"TLS feature/config error. Captured logs: "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+        assert "feature is not enabled" not in all_messages and "invalidclientconfig" not in all_messages, (
+            "rediss:// failure looks like the wo-tracker #68217 regression "
+            f"(TLS feature not compiled). Captured logs: "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+
+


### PR DESCRIPTION
## Summary

Enables TLS for the rate limiter's Redis backend so deployments against managed Redis services with in-transit encryption (AWS ElastiCache, Redis Cloud, etc.) work end-to-end. Bumps `cpex_rate_limiter` 0.0.4 → 0.0.6.

---

## Gaps closed

**Gap A (HIGH)** — The Redis backend cannot connect to managed Redis services that require TLS. Operators using AWS ElastiCache with in-transit encryption (or any other `rediss://` URL) can configure the binding successfully — the binding API returns HTTP 200 — but the plugin's backend init raises `InvalidClientConfig: can't connect with TLS, the feature is not enabled`. The plugin manager logs `Failed to load plugin RateLimiterPlugin` and silently skips it under the default `fail_on_plugin_error: false` setting, leaving rate limits unenforced while the operator believes them to be in place. Fixed by compiling the redis crate with rustls-based TLS features.

**Gap B (MEDIUM)** — The redis crate version previously pinned (0.27) carried `rustls-pemfile` 2.2.0 transitively, which `cargo-deny` flagged as unmaintained (RUSTSEC-2025-0134) and blocked CI's `security-policy` stage. Fixed by bumping the redis crate to 0.32, where the rustls-native-certs upgrade dropped the `rustls-pemfile` dep entirely.

**Gap C (MEDIUM)** — rustls 0.23 dropped its implicit default crypto provider; the redis crate's `tls-rustls` feature does not pick one. Without an explicit install, the first TLS handshake panicked with `Call CryptoProvider::install_default() before this point...`. The Python shim's broad except caught the panic and `fail_mode=open` allowed the request through, so deployments would still appear to load the plugin while quietly enforcing nothing — same observable end state as Gap A, different log message. Fixed by installing the `ring` crypto provider once at plugin init via a `OnceLock`-guarded call in `RateLimiterPluginCore::new()`.

---

## Test results

<details>
<summary>Full local gate</summary>

```text
cargo fmt -- --check                  clean
cargo clippy -- -D warnings           clean
cargo test --lib                      57 passed
uv run pytest tests/rate_limiter/     107 passed
```

</details>

<details>
<summary>New tests added in this PR</summary>

**`TestRedisTlsSupport`** — regression coverage for managed-Redis TLS support

| Test | Target |
|---|---|
| `test_rediss_url_does_not_fail_with_tls_not_enabled` | Constructs the plugin with a `rediss://` URL; asserts no `InvalidClientConfig` is raised at backend init. Pins Gap A. |
| `test_rediss_url_lazy_handshake_reaches_connectivity_layer` | Drives a `tool_pre_invoke` against a closed `rediss://` port so the lazy TLS handshake actually engages; asserts the captured warning does not contain the TLS-feature-not-enabled signature (`feature is not enabled` / `InvalidClientConfig`). Pins Gap A and Gap C jointly. |

</details>

---

## Migration notes

- **No new required config.** Existing deployments using `redis://` URLs continue to work unchanged. `rediss://` URLs now work where they previously failed.
- **CA bundle expectation.** The plugin reads CA roots from the host OS trust store at runtime via `rustls-native-certs`. Container images that omit `ca-certificates` (some distroless / scratch / unconfigured Alpine variants) would need to install the bundle before TLS endpoints can be verified. UBI Minimal — what mcp-context-forge ships on — already includes the CA bundle by default; AWS ElastiCache uses public-CA chains that are present there.

---

## Follow-ups

- Tighten the TLS lazy-handshake test's positive assertion (currently scoped to the TLS-feature-not-enabled negative signature only). Would require the Rust core's `log_exception()` to surface the underlying `RedisError` text instead of the generic "error; allowing request" message — the error details are dropped at the Python boundary today.
- Real-TLS-Redis fixture for end-to-end handshake verification (self-signed cert + CA-pinning fixture). Heavier than the connectivity-shape variant; deferred until needed.
- Companion main-repo PR to bump the `cpex-rate-limiter` pin to 0.0.5 once published to PyPI.
- Wipe-on-disable feature (counter cleanup when an operator transitions the plugin to `mode=disabled`) and the round-1/round-2 review feedback addressing it have been moved to a separate branch (`feat/rate-limiter-wipe-on-disable-only`); a follow-up PR will be linked here once opened.

