### PR TITLE
feat(rate-limiter): wipe Redis counter state on disable transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -81,9 +81,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -114,9 +114,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
 ]
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -552,13 +552,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -566,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -579,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -593,15 +592,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -613,15 +612,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -651,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -661,12 +660,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -727,12 +726,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -751,15 +748,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -1085,18 +1082,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1275,9 +1272,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1305,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "rate_limiter"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",
@@ -1328,9 +1325,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1531,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1748,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1783,9 +1780,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -1800,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1863,9 +1860,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unic-char-property"
@@ -2020,9 +2017,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2053,11 +2050,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2066,14 +2063,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2084,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2094,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2107,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2150,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2332,9 +2329,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -2344,12 +2341,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2432,15 +2423,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2449,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2481,18 +2472,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2502,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2513,9 +2504,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2524,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rate_limiter"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/rate_limiter/README.md
+++ b/plugins/rust/python-package/rate_limiter/README.md
@@ -205,6 +205,16 @@ The plugin participates in the plugin manager's lifecycle contract:
 
 Without `shutdown`, the cached Redis connection would leak across plugin re-instantiation, producing connection churn on the server.
 
+### Disabling resets counters
+
+When an operator sets the plugin's mode to `disabled` via the gateway's admin mode API, every Redis key matching the plugin's configured `redis_key_prefix` (default `rl:*`) is deleted on shutdown. Re-enabling the plugin starts every user with a fresh window — counters do **not** resume from the pre-disable state.
+
+This makes the rate limiter behave like a stateless plugin from the operator's perspective across mode transitions: flipping `disabled` ⇄ `enforce` is the equivalent of a fresh deploy, not a paused-and-resumed counter. Frequent toggling is therefore discouraged — every flip discards counter history.
+
+The wipe is conditional on the admin mode API path: `publish_plugin_mode_change` writes `plugin:<name>:mode` to Redis *before* publishing the pub/sub broadcast that triggers shutdown. The plugin's `shutdown()` reads that key and only wipes when its value is exactly `"disabled"`. On a graceful pod shutdown the key is unchanged (it stays at whatever the operator last set, almost always `enforce`), so counters survive restarts.
+
+**Known limitation:** mode changes made through the per-tenant binding API (`POST /v1/tools/plugin_bindings`) do **not** currently trigger a wipe — the binding-API path stores the mode in the database rather than in `plugin:<name>:mode`, so the shutdown-time check returns False. Tracked for a follow-up.
+
 ## Limitations
 
 | Limitation | Severity | Status |

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Contributors"
-version: "0.0.5"
+version: "0.0.6"
 kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/rate_limiter.py
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/rate_limiter.py
@@ -74,16 +74,123 @@ class RateLimiterPlugin(Plugin):
         _logger.info("rate limiter initialized: backend=%s", backend)
 
     async def shutdown(self) -> None:
-        """Lifecycle hook: release Rust-held resources (e.g. Redis connection).
+        """Lifecycle hook: wipe counters if mode just transitioned to disabled,
+        then release Rust-held resources (e.g. Redis connection).
 
         The plugin manager calls this on disable and on re-instantiation.
-        Without it, the cached Redis connection leaks until the plugin
-        instance is garbage-collected.
+        Without core.shutdown() the cached Redis connection leaks until the
+        plugin instance is garbage-collected.
+
+        Wipe behaviour: if the operator has just set this plugin's mode to
+        "disabled" via the admin mode API, every rate-limit counter for this
+        plugin's configured key prefix is deleted from Redis before shutdown
+        completes. Re-enabling then starts every user with a fresh window.
+        See README "Disabling resets counters" for the contract details and
+        the binding-API limitation.
         """
         try:
-            self._core.shutdown()
+            if await self._mode_in_redis_says_disabled():
+                await self._wipe_my_counters()
         except Exception:
-            _logger.exception("rate limiter shutdown: core.shutdown() raised")
+            _logger.exception("rate limiter shutdown: wipe-on-disable check failed")
+        finally:
+            try:
+                self._core.shutdown()
+            except Exception:
+                _logger.exception("rate limiter shutdown: core.shutdown() raised")
+
+    async def _mode_in_redis_says_disabled(self) -> bool:
+        """Return True only when the admin mode API has set this plugin's
+        mode to "disabled".
+
+        ``publish_plugin_mode_change`` (in mcp-context-forge) writes
+        ``plugin:<name>:mode`` to Redis *before* broadcasting the pub/sub
+        invalidation. By the time this method runs in response to that
+        invalidation, the Redis key authoritatively reflects the new mode
+        — there is no race window where the key still says ``enforce``.
+
+        Any error (Redis unreachable, key absent, value not "disabled")
+        returns False so the wipe never fires accidentally. This is the
+        graceful-shutdown safety property: a pod restart leaves the Redis
+        mode key untouched (it stays at whatever the operator last set,
+        almost always not "disabled"), so counters survive restarts.
+        """
+        cfg = self.config.config or {}
+        if cfg.get("backend") != "redis":
+            return False
+        redis_url = cfg.get("redis_url")
+        if not redis_url:
+            return False
+        try:
+            import redis.asyncio as aioredis  # noqa: PLC0415
+        except Exception:
+            return False
+        try:
+            client = aioredis.from_url(redis_url, decode_responses=True)
+        except Exception:
+            return False
+        try:
+            try:
+                value = await client.get(f"plugin:{self.config.name}:mode")
+            except Exception:
+                return False
+        finally:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+        return value == "disabled"
+
+    async def _wipe_my_counters(self) -> None:
+        """Delete every Redis key matching this plugin's configured prefix.
+
+        Uses SCAN (non-blocking, cursor-paged) rather than KEYS so this is
+        safe to run against production Redis with large keyspaces. Deletions
+        are batched so each round-trip drops up to 500 keys at once.
+
+        Idempotent under multi-worker races: when several workers all flip
+        to disabled simultaneously, every worker calls this; DEL of an
+        already-absent key is a no-op, so the duplicated work is harmless.
+        """
+        cfg = self.config.config or {}
+        redis_url = cfg.get("redis_url")
+        if not redis_url:
+            return
+        prefix = cfg.get("redis_key_prefix", "rl")
+        pattern = f"{prefix}:*"
+        try:
+            import redis.asyncio as aioredis  # noqa: PLC0415
+        except Exception:
+            return
+        try:
+            client = aioredis.from_url(redis_url)
+        except Exception:
+            return
+        try:
+            batch: list = []
+            deleted = 0
+            async for key in client.scan_iter(match=pattern, count=500):
+                batch.append(key)
+                if len(batch) >= 500:
+                    deleted += await client.delete(*batch)
+                    batch.clear()
+            if batch:
+                deleted += await client.delete(*batch)
+            _logger.info(
+                "rate limiter wipe-on-disable: deleted %d keys matching %s",
+                deleted,
+                pattern,
+            )
+        except Exception:
+            _logger.exception(
+                "rate limiter wipe-on-disable: scan/delete failed for pattern %s",
+                pattern,
+            )
+        finally:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
 
     async def prompt_pre_fetch(self, payload, context):
         # The Rust core handles fail_mode policy internally (open vs closed)

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/rate_limiter.py
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/rate_limiter.py
@@ -59,6 +59,11 @@ class RateLimiterConfig:
 
 _logger = logging.getLogger(__name__)
 
+# Single-flight wipe lock TTL. Comfortably longer than any reasonable
+# wipe-on-disable should take; bounds worst-case starvation if the
+# lock-holder dies mid-wipe.
+_WIPE_LOCK_TTL_SECONDS = 30
+
 
 class RateLimiterPlugin(Plugin):
     """Gateway-facing Plugin subclass that delegates behavior to Rust."""
@@ -90,7 +95,17 @@ class RateLimiterPlugin(Plugin):
         """
         try:
             if await self._mode_in_redis_says_disabled():
-                await self._wipe_my_counters()
+                # Single-flight guard: in a fleet (N replicas × M workers),
+                # all instances see the same `mode=disabled` signal. Without
+                # this guard, every worker independently runs SCAN+DEL,
+                # producing N*M times the Redis work and competing on the
+                # same keyspace. The lock ensures exactly one worker per
+                # disable cycle performs the wipe; the rest skip cleanly.
+                if await self._acquire_wipe_lock():
+                    try:
+                        await self._wipe_my_counters()
+                    finally:
+                        await self._release_wipe_lock()
         except Exception:
             _logger.exception("rate limiter shutdown: wipe-on-disable check failed")
         finally:
@@ -141,16 +156,110 @@ class RateLimiterPlugin(Plugin):
                 pass
         return value == "disabled"
 
+    def _wipe_lock_key(self) -> str:
+        """Return the Redis key used to single-flight the wipe.
+
+        Uses a dash separator so the lock key is *outside* the wipe SCAN's
+        glob pattern (``<prefix>:*``). Otherwise the wipe would delete its
+        own lock mid-pass.
+        """
+        cfg = self.config.config or {}
+        prefix = cfg.get("redis_key_prefix", "rl")
+        return f"{prefix}-wipe-lock"
+
+    async def _acquire_wipe_lock(self) -> bool:
+        """Atomically claim the right to perform the wipe.
+
+        Uses ``SET key 1 NX EX <ttl>``: only one caller can succeed within
+        the TTL window. The TTL bounds starvation if the lock-holder dies
+        mid-wipe — the next disable cycle reclaims the lock.
+
+        Any error (Redis unreachable, client construction fails) returns
+        False so we err on "skip the wipe" rather than racing without
+        protection.
+        """
+        cfg = self.config.config or {}
+        if cfg.get("backend") != "redis":
+            return False
+        redis_url = cfg.get("redis_url")
+        if not redis_url:
+            return False
+        try:
+            import redis.asyncio as aioredis  # noqa: PLC0415
+        except Exception:
+            return False
+        try:
+            client = aioredis.from_url(redis_url, decode_responses=True)
+        except Exception:
+            return False
+        try:
+            try:
+                acquired = await client.set(
+                    self._wipe_lock_key(),
+                    "1",
+                    nx=True,
+                    ex=_WIPE_LOCK_TTL_SECONDS,
+                )
+            except Exception:
+                return False
+        finally:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+        return bool(acquired)
+
+    async def _release_wipe_lock(self) -> None:
+        """Drop the wipe lock so the next disable cycle is responsive.
+
+        The TTL is the safety net; this is just an optimization to avoid
+        waiting up to ``_WIPE_LOCK_TTL_SECONDS`` for the next legitimate
+        wipe to proceed. Best-effort: any error is swallowed.
+        """
+        cfg = self.config.config or {}
+        redis_url = cfg.get("redis_url")
+        if not redis_url:
+            return
+        try:
+            import redis.asyncio as aioredis  # noqa: PLC0415
+        except Exception:
+            return
+        try:
+            client = aioredis.from_url(redis_url, decode_responses=True)
+        except Exception:
+            return
+        try:
+            try:
+                await client.delete(self._wipe_lock_key())
+            except Exception:
+                pass
+        finally:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+
     async def _wipe_my_counters(self) -> None:
         """Delete every Redis key matching this plugin's configured prefix.
 
         Uses SCAN (non-blocking, cursor-paged) rather than KEYS so this is
         safe to run against production Redis with large keyspaces. Deletions
-        are batched so each round-trip drops up to 500 keys at once.
+        are batched so each round-trip drops up to 500 keys at once — large
+        enough to keep round-trip count low, small enough that a single
+        UNLINK/DEL command never grows pathologically.
+
+        Prefers UNLINK (Redis 4.0+) over DEL: UNLINK frees value memory on a
+        background thread, so dropping a batch of sliding-window sorted
+        sets does not stutter Redis' main-thread serving other clients.
+        Falls back to DEL on Redis < 4.0 (rare in practice — ElastiCache,
+        Redis Cloud, and every modern self-hosted deployment supports
+        UNLINK).
 
         Idempotent under multi-worker races: when several workers all flip
-        to disabled simultaneously, every worker calls this; DEL of an
-        already-absent key is a no-op, so the duplicated work is harmless.
+        to disabled simultaneously, every worker calls this; UNLINK / DEL
+        of an already-absent key is a no-op, so the duplicated work is
+        harmless. (In practice the single-flight guard in shutdown() means
+        only one worker reaches here per disable cycle.)
         """
         cfg = self.config.config or {}
         redis_url = cfg.get("redis_url")
@@ -160,22 +269,32 @@ class RateLimiterPlugin(Plugin):
         pattern = f"{prefix}:*"
         try:
             import redis.asyncio as aioredis  # noqa: PLC0415
+            from redis.exceptions import ResponseError  # noqa: PLC0415
         except Exception:
             return
         try:
             client = aioredis.from_url(redis_url)
         except Exception:
             return
+
+        async def _drop(keys: list) -> int:
+            """UNLINK with DEL fallback for pre-4.0 Redis."""
+            try:
+                return await client.unlink(*keys)
+            except ResponseError:
+                # ERR unknown command 'UNLINK' on Redis < 4.0 — fall back.
+                return await client.delete(*keys)
+
         try:
             batch: list = []
             deleted = 0
             async for key in client.scan_iter(match=pattern, count=500):
                 batch.append(key)
                 if len(batch) >= 500:
-                    deleted += await client.delete(*batch)
+                    deleted += await _drop(batch)
                     batch.clear()
             if batch:
-                deleted += await client.delete(*batch)
+                deleted += await _drop(batch)
             _logger.info(
                 "rate limiter wipe-on-disable: deleted %d keys matching %s",
                 deleted,

--- a/plugins/rust/python-package/rate_limiter/pyproject.toml
+++ b/plugins/rust/python-package/rate_limiter/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+dependencies = [
+    "redis>=5.0",
+]
 
 [project.entry-points."cpex.plugins"]
 rate_limiter = "cpex_rate_limiter.rate_limiter:RateLimiterPlugin"

--- a/plugins/rust/python-package/rate_limiter/uv.lock
+++ b/plugins/rust/python-package/rate_limiter/uv.lock
@@ -23,6 +23,9 @@ wheels = [
 [[package]]
 name = "cpex-rate-limiter"
 source = { editable = "." }
+dependencies = [
+    { name = "redis" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -33,6 +36,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "redis", specifier = ">=5.0" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -46,7 +46,7 @@ from cpex_rate_limiter.rate_limiter import RateLimiterPlugin
 def rate_limit_plugin_2_per_second():
     """Rate limiter plugin configured for 2 requests per second."""
     config = PluginConfig(
-        name="RateLimiter",
+        name="RateLimiterPlugin",
         kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
         hooks=["prompt_pre_fetch", "tool_pre_invoke"],
         priority=100,
@@ -59,7 +59,7 @@ def rate_limit_plugin_2_per_second():
 def rate_limit_plugin_multi_dimensional():
     """Rate limiter plugin with multi-dimensional limits."""
     config = PluginConfig(
-        name="RateLimiter",
+        name="RateLimiterPlugin",
         kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
         hooks=["prompt_pre_fetch", "tool_pre_invoke"],
         priority=100,
@@ -228,7 +228,7 @@ class TestMultiDimensionalRateLimiting:
         """Verify user rate limits are enforced independently per user."""
         # Configure with ONLY user limits (no tenant limit)
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch"],
             priority=100,
@@ -303,7 +303,7 @@ class TestMultiDimensionalRateLimiting:
         """Verify most restrictive dimension is selected."""
         # Configure with different limits
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch"],
             priority=100,
@@ -372,7 +372,7 @@ class TestSlidingWindowIntegration:
     @pytest.fixture
     def plugin(self):
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch", "tool_pre_invoke"],
             priority=100,
@@ -461,7 +461,7 @@ class TestTokenBucketIntegration:
     @pytest.fixture
     def plugin(self):
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch", "tool_pre_invoke"],
             priority=100,
@@ -554,7 +554,7 @@ class TestCrossHookSharing:
     @pytest.fixture
     def plugin(self):
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch", "tool_pre_invoke"],
             priority=100,
@@ -602,7 +602,7 @@ class TestCrossHookSharing:
     async def test_tenant_counter_shared_across_hooks_and_users(self, plugin):
         """Tenant bucket is shared across all users in the same tenant, regardless of hook."""
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["prompt_pre_fetch", "tool_pre_invoke"],
             priority=100,
@@ -644,7 +644,7 @@ class TestTenantIsolation:
     @pytest.fixture
     def plugin(self):
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             priority=100,
@@ -732,7 +732,7 @@ class TestTenantIsolation:
         Uses a high by_user limit so only by_tenant could trigger a block.
         """
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             priority=100,
@@ -778,7 +778,7 @@ class TestTenantIsolation:
         Uses a high by_user limit so only by_tenant can trigger a block.
         """
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             priority=100,
@@ -807,7 +807,7 @@ class TestNoLimitsAndMissingContext:
     async def test_no_limits_configured_allows_all_requests(self):
         """Plugin with all dimensions None must allow every request without tracking."""
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             config={},  # no by_user, no by_tenant, no by_tool
@@ -824,7 +824,7 @@ class TestNoLimitsAndMissingContext:
     async def test_no_limits_configured_returns_no_headers(self):
         """Plugin with no configured limits must not set X-RateLimit-* headers."""
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             config={},
@@ -840,7 +840,7 @@ class TestNoLimitsAndMissingContext:
     async def test_both_user_and_tenant_none_still_enforces(self):
         """With both user=None and tenant_id=None the plugin must still enforce limits."""
         config = PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             config={"by_user": "2/s", "by_tenant": "10/s"},
@@ -862,7 +862,7 @@ class TestNoLimitsAndMissingContext:
         def make_plugin():
             return RateLimiterPlugin(
                 PluginConfig(
-                    name="RateLimiter",
+                    name="RateLimiterPlugin",
                     kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
                     hooks=["tool_pre_invoke"],
                     config={"by_user": "2/s"},
@@ -1017,7 +1017,7 @@ def _make_redis_plugin(redis_url: str, algorithm: str = "fixed_window", limit: s
     """Create a RateLimiterPlugin backed by real Redis."""
     return RateLimiterPlugin(
         PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             priority=100,
@@ -1387,7 +1387,7 @@ def _make_redis_plugin_with_config(redis_url: str, extra_config: dict) -> RateLi
     base.update(extra_config)
     return RateLimiterPlugin(
         PluginConfig(
-            name="RateLimiter",
+            name="RateLimiterPlugin",
             kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
             hooks=["tool_pre_invoke"],
             priority=100,
@@ -1419,7 +1419,7 @@ class TestRedisFailModeAndViolationContext:
 
         plugin = RateLimiterPlugin(
             PluginConfig(
-                name="RateLimiter",
+                name="RateLimiterPlugin",
                 kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
                 hooks=["tool_pre_invoke"],
                 priority=100,
@@ -1557,7 +1557,7 @@ class TestConfigHardening:
         with caplog.at_level(logging.WARNING):
             RateLimiterPlugin(
                 PluginConfig(
-                    name="RateLimiter",
+                    name="RateLimiterPlugin",
                     kind="cpex_rate_limiter.rate_limiter.RateLimiterPlugin",
                     hooks=["tool_pre_invoke"],
                     priority=100,
@@ -1640,7 +1640,7 @@ class TestWipeOnDisable:
         """mode='disabled' in Redis → all rl:* keys are deleted on shutdown."""
         await _flush_redis(redis_url_for_integration)
         await _seed_rate_limit_counters(redis_url_for_integration, count=5)
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         keys_before = await _keys_in_redis(redis_url_for_integration, "rl:*")
         assert len(keys_before) == 5, "seeding should have produced 5 rl:* keys"
@@ -1659,7 +1659,7 @@ class TestWipeOnDisable:
         """mode='enforce' in Redis → counters survive shutdown (config-only edit)."""
         await _flush_redis(redis_url_for_integration)
         await _seed_rate_limit_counters(redis_url_for_integration, count=3)
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "enforce")
 
         plugin = _make_redis_plugin(redis_url_for_integration)
         await plugin.shutdown()
@@ -1676,7 +1676,7 @@ class TestWipeOnDisable:
         await _flush_redis(redis_url_for_integration)
         await _seed_rate_limit_counters(redis_url_for_integration, count=3)
         # Explicitly ensure the mode key does not exist (fresh-deploy / pod-restart shape).
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", None)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", None)
 
         plugin = _make_redis_plugin(redis_url_for_integration)
         await plugin.shutdown()
@@ -1704,7 +1704,7 @@ class TestWipeOnDisable:
         """Multiple plugin instances calling shutdown() in parallel all succeed and converge."""
         await _flush_redis(redis_url_for_integration)
         await _seed_rate_limit_counters(redis_url_for_integration, count=10)
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         plugins = [_make_redis_plugin(redis_url_for_integration) for _ in range(5)]
 
@@ -1731,7 +1731,7 @@ class TestWipeOnDisable:
         TestRedisLifecycle.test_shutdown_releases_redis_connection.
         """
         await _flush_redis(redis_url_for_integration)
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         plugin = _make_redis_plugin(redis_url_for_integration)
         ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
@@ -1769,7 +1769,7 @@ class TestWipeOnDisable:
         """
         await _flush_redis(redis_url_for_integration)
         await _seed_rate_limit_counters(redis_url_for_integration, count=5)
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         # Pre-acquire the wipe lock externally — pretend another worker is
         # already in the middle of wiping. Default redis_key_prefix is "rl",
@@ -1816,7 +1816,7 @@ class TestWipeOnDisable:
         finally:
             await client.aclose()
 
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         plugin = _make_redis_plugin_with_config(
             redis_url_for_integration,
@@ -1880,7 +1880,7 @@ class TestWipeOnDisable:
         )
 
         # ── Phase 2: operator toggles to disabled — wipe must fire ──────
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
         await plugin.shutdown()
 
         keys_post_wipe = await _keys_in_redis(redis_url_for_integration, "rl:*")
@@ -1893,7 +1893,7 @@ class TestWipeOnDisable:
         # Constructing a new plugin instance is what the framework's plugin
         # manager does on re-enable; the manager adds nothing at construction
         # beyond what _make_redis_plugin reproduces here.
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "enforce")
         plugin = _make_redis_plugin(redis_url_for_integration, limit="3/m")
 
         r = await plugin.tool_pre_invoke(payload, ctx)
@@ -1965,7 +1965,7 @@ class TestWipeOnDisable:
             )
 
         # ── Phase 2: parallel disable — exactly one wipes, all keys gone ──
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "disabled")
 
         results = await asyncio.gather(
             *(p.shutdown() for p in plugins),
@@ -1985,7 +1985,7 @@ class TestWipeOnDisable:
         # ── Phase 3: re-enforce — every user gets a fresh window ──
         # Fresh plugin instances mirror what each worker's plugin manager does
         # on re-enable.
-        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiterPlugin", "enforce")
         fresh_plugins = [_make_redis_plugin(redis_url_for_integration, limit="3/m") for _ in users]
 
         async def _first_request_passes(plugin, ctx, user):

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1757,3 +1757,81 @@ class TestWipeOnDisable:
             "core.shutdown() must run even when wipe raises — expected the "
             f"Rust core's connection to be released (before={clients_before} after={clients_after})"
         )
+
+    @pytest.mark.asyncio
+    async def test_wipe_skipped_when_another_worker_holds_lock(self, redis_url_for_integration):
+        """Single-flight guard: when another worker is already wiping, this shutdown skips.
+
+        Simulates the lock-already-held state by SETting the lock key
+        externally before invoking shutdown. With the lock held, the wipe
+        path must not run — observable by counters surviving the shutdown
+        despite mode=disabled.
+        """
+        await _flush_redis(redis_url_for_integration)
+        await _seed_rate_limit_counters(redis_url_for_integration, count=5)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        # Pre-acquire the wipe lock externally — pretend another worker is
+        # already in the middle of wiping. Default redis_key_prefix is "rl",
+        # so the lock key is "rl-wipe-lock".
+        # Third-Party
+        import redis.asyncio as aioredis  # noqa: PLC0415
+
+        client = aioredis.from_url(redis_url_for_integration, decode_responses=True)
+        try:
+            await client.set("rl-wipe-lock", "1", nx=True, ex=30)
+        finally:
+            await client.aclose()
+
+        plugin = _make_redis_plugin(redis_url_for_integration)
+        await plugin.shutdown()
+
+        # Counters survive — proves we did NOT take the wipe path.
+        keys_after = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert len(keys_after) == 5, (
+            "shutdown must skip the wipe when another worker holds the lock — "
+            f"expected 5 rl:* keys to survive, got {keys_after}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wipe_only_deletes_keys_under_configured_prefix(self, redis_url_for_integration):
+        """Wipe respects the plugin's configured ``redis_key_prefix``.
+
+        A regression that hard-coded ``rl:*`` (the default prefix) would still
+        pass every other test in this class, because they all use the default
+        prefix. This test pins the contract: only keys under the plugin's
+        configured prefix are deleted; adjacent namespaces survive.
+        """
+        await _flush_redis(redis_url_for_integration)
+
+        # Seed both: a key under our custom prefix (must be wiped) and a key
+        # under an unrelated prefix (must survive).
+        # Third-Party
+        import redis.asyncio as aioredis  # noqa: PLC0415
+
+        client = aioredis.from_url(redis_url_for_integration, decode_responses=True)
+        try:
+            await client.set("custom_pfx:user:alice:60", "5")
+            await client.set("other_ns:user:bob:60", "5")
+        finally:
+            await client.aclose()
+
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        plugin = _make_redis_plugin_with_config(
+            redis_url_for_integration,
+            {"redis_key_prefix": "custom_pfx"},
+        )
+        await plugin.shutdown()
+
+        custom_keys = await _keys_in_redis(redis_url_for_integration, "custom_pfx:*")
+        other_keys = await _keys_in_redis(redis_url_for_integration, "other_ns:*")
+
+        assert custom_keys == [], (
+            "wipe must delete every key under the configured prefix — "
+            f"expected [], got {custom_keys}"
+        )
+        assert other_keys == ["other_ns:user:bob:60"], (
+            "wipe must NOT touch keys outside the configured prefix — "
+            f"expected ['other_ns:user:bob:60'], got {other_keys}"
+        )

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1835,3 +1835,71 @@ class TestWipeOnDisable:
             "wipe must NOT touch keys outside the configured prefix — "
             f"expected ['other_ns:user:bob:60'], got {other_keys}"
         )
+
+    @pytest.mark.asyncio
+    async def test_full_toggle_journey_enforce_disable_reenforce(self, redis_url_for_integration):
+        """Operator journey end-to-end: enforce → saturate → disable wipes → re-enable starts fresh.
+
+        Mirrors User Story 1 of mcp-context-forge#4576 — the operator-visible
+        contract is that flipping a saturated rate-limiter to ``disabled`` and
+        then back to ``enforce`` must give the affected user a fresh window,
+        not an immediate block on stale counter state.
+
+        The other tests in this class assert wipe invariants in isolation
+        (does the wipe fire on disable, does it skip when it should, does
+        it respect the prefix). None of them assert the *transition*
+        composes — specifically, none verify that a user who *was being
+        blocked* stops being blocked after a full toggle cycle. This test
+        pins that contract.
+
+        Window is sized at 3/m rather than 3/s so the test never straddles
+        a second boundary on slow runners — without the wipe, alice's 5th
+        request would fall in the same minute window as her saturated
+        bucket and be blocked, so a passing 5th request after the cycle
+        is unambiguous evidence the wipe ran.
+        """
+        await _flush_redis(redis_url_for_integration)
+
+        # ── Phase 1: enforce — saturate alice's bucket ──────────────────
+        plugin = _make_redis_plugin(redis_url_for_integration, limit="3/m")
+        ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
+        payload = ToolPreInvokePayload(name="t", arguments={})
+
+        for i in range(3):
+            r = await plugin.tool_pre_invoke(payload, ctx)
+            assert r.continue_processing, f"request {i + 1}/3 must pass under 3/m"
+
+        blocked = await plugin.tool_pre_invoke(payload, ctx)
+        assert blocked.continue_processing is False, (
+            "4th request must be blocked — alice's bucket should be saturated "
+            "before the operator triggers disable"
+        )
+        keys_pre_disable = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert any("alice" in k for k in keys_pre_disable), (
+            f"alice's counter key should exist before disable; got {keys_pre_disable}"
+        )
+
+        # ── Phase 2: operator toggles to disabled — wipe must fire ──────
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+        await plugin.shutdown()
+
+        keys_post_wipe = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert keys_post_wipe == [], (
+            "shutdown under mode=disabled must wipe alice's saturated bucket — "
+            f"expected [], got {keys_post_wipe}"
+        )
+
+        # ── Phase 3: operator toggles back to enforce — fresh window ────
+        # Constructing a new plugin instance is what the framework's plugin
+        # manager does on re-enable; the manager adds nothing at construction
+        # beyond what _make_redis_plugin reproduces here.
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+        plugin = _make_redis_plugin(redis_url_for_integration, limit="3/m")
+
+        r = await plugin.tool_pre_invoke(payload, ctx)
+        assert r.continue_processing, (
+            "alice was saturated pre-disable; after the wipe + re-enable, the "
+            "first request in the same minute window must NOT be blocked by "
+            "stale counter state — this is the user-visible promise of "
+            "wipe-on-disable"
+        )

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1578,3 +1578,182 @@ class TestConfigHardening:
             "engine must warn on unknown config keys so misspellings are visible — "
             f"captured records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for wipe-on-disable tests
+# ---------------------------------------------------------------------------
+
+
+async def _set_plugin_mode_key(redis_url: str, plugin_name: str, mode: str | None) -> None:
+    """Set or delete plugin:<name>:mode in Redis.
+
+    ``mode=None`` deletes the key (simulates a fresh deploy where no operator
+    has touched the admin mode API yet).
+    """
+    # Third-Party
+    import redis.asyncio as aioredis  # noqa: PLC0415
+
+    client = aioredis.from_url(redis_url, decode_responses=True)
+    try:
+        key = f"plugin:{plugin_name}:mode"
+        if mode is None:
+            await client.delete(key)
+        else:
+            await client.set(key, mode)
+    finally:
+        await client.aclose()
+
+
+async def _seed_rate_limit_counters(redis_url: str, count: int = 3) -> None:
+    """Drop ``count`` rl:* keys into Redis to simulate accumulated counter state."""
+    # Third-Party
+    import redis.asyncio as aioredis  # noqa: PLC0415
+
+    client = aioredis.from_url(redis_url, decode_responses=True)
+    try:
+        for i in range(count):
+            await client.set(f"rl:test:user:user-{i}:60", "5", ex=60)
+    finally:
+        await client.aclose()
+
+
+class TestWipeOnDisable:
+    """Counter wipe when operator transitions plugin mode to 'disabled'.
+
+    Rationale (team alignment, see README "Disabling resets counters"):
+    when the operator flips the rate limiter to disabled, every rate-limit
+    counter should be cleared so re-enabling starts every user with a
+    fresh window. The plugin signals this transition by reading
+    ``plugin:<name>:mode`` from Redis at shutdown — that key is written by
+    ``publish_plugin_mode_change`` *before* the pub/sub broadcast that
+    triggers the shutdown, so it is authoritative by the time we read it.
+
+    The wipe must NOT fire on:
+      * graceful pod shutdown (mode key unchanged, almost always 'enforce')
+      * non-mode config edits (mode key unchanged)
+      * Redis-unreachable shutdown paths (fail-safe: don't accidentally wipe)
+    """
+
+    @pytest.mark.asyncio
+    async def test_wipe_fires_when_mode_key_says_disabled(self, redis_url_for_integration):
+        """mode='disabled' in Redis → all rl:* keys are deleted on shutdown."""
+        await _flush_redis(redis_url_for_integration)
+        await _seed_rate_limit_counters(redis_url_for_integration, count=5)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        keys_before = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert len(keys_before) == 5, "seeding should have produced 5 rl:* keys"
+
+        plugin = _make_redis_plugin(redis_url_for_integration)
+        await plugin.shutdown()
+
+        keys_after = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert keys_after == [], (
+            "shutdown with mode='disabled' must wipe every rl:* key — "
+            f"expected [], got {keys_after}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_wipe_when_mode_key_says_enforce(self, redis_url_for_integration):
+        """mode='enforce' in Redis → counters survive shutdown (config-only edit)."""
+        await _flush_redis(redis_url_for_integration)
+        await _seed_rate_limit_counters(redis_url_for_integration, count=3)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+
+        plugin = _make_redis_plugin(redis_url_for_integration)
+        await plugin.shutdown()
+
+        keys_after = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert len(keys_after) == 3, (
+            "shutdown with mode='enforce' must NOT wipe counters — "
+            f"expected 3 rl:* keys, got {keys_after}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_wipe_when_mode_key_absent(self, redis_url_for_integration):
+        """No mode key in Redis → graceful shutdown safety: counters survive."""
+        await _flush_redis(redis_url_for_integration)
+        await _seed_rate_limit_counters(redis_url_for_integration, count=3)
+        # Explicitly ensure the mode key does not exist (fresh-deploy / pod-restart shape).
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", None)
+
+        plugin = _make_redis_plugin(redis_url_for_integration)
+        await plugin.shutdown()
+
+        keys_after = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert len(keys_after) == 3, (
+            "shutdown with no mode key must NOT wipe counters (graceful shutdown safety) — "
+            f"expected 3 rl:* keys, got {keys_after}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_wipe_when_redis_unreachable_for_mode_lookup(self):
+        """Redis unreachable → mode lookup fails → fail-safe: no wipe attempted, no exception escapes."""
+        # The plugin's redis_url points nowhere. We never connect to set up
+        # state — there is no state to set up. We just need shutdown to
+        # complete cleanly without raising.
+        plugin = _make_redis_plugin(_DEAD_REDIS_URL)
+
+        # Must not raise; must not hang. Any error inside the wipe path
+        # should be swallowed and core.shutdown() should still run.
+        await plugin.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_wipe_is_idempotent_under_concurrent_shutdown(self, redis_url_for_integration):
+        """Multiple plugin instances calling shutdown() in parallel all succeed and converge."""
+        await _flush_redis(redis_url_for_integration)
+        await _seed_rate_limit_counters(redis_url_for_integration, count=10)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        plugins = [_make_redis_plugin(redis_url_for_integration) for _ in range(5)]
+
+        results = await asyncio.gather(
+            *(p.shutdown() for p in plugins),
+            return_exceptions=True,
+        )
+        for i, r in enumerate(results):
+            assert not isinstance(r, BaseException), (
+                f"plugin[{i}].shutdown() raised under concurrent wipe — got {r!r}"
+            )
+
+        keys_after = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert keys_after == [], (
+            "concurrent shutdowns must converge to all keys deleted — "
+            f"expected [], got {keys_after}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_core_shutdown_runs_even_when_wipe_raises(self, redis_url_for_integration):
+        """If wipe raises mid-shutdown, core.shutdown() must still execute and release the Redis connection.
+
+        Verified via the same client-count delta pattern used by
+        TestRedisLifecycle.test_shutdown_releases_redis_connection.
+        """
+        await _flush_redis(redis_url_for_integration)
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        plugin = _make_redis_plugin(redis_url_for_integration)
+        ctx = PluginContext(global_context=GlobalContext(request_id="r1", user="alice"))
+        payload = ToolPreInvokePayload(name="tool", arguments={})
+
+        # Warm the Rust core's cached Redis connection.
+        await plugin.tool_pre_invoke(payload, ctx)
+        clients_before = await _count_redis_clients(redis_url_for_integration)
+
+        # Force the wipe path to raise.
+        async def _boom() -> None:
+            raise RuntimeError("simulated wipe failure")
+
+        plugin._wipe_my_counters = _boom  # type: ignore[method-assign]
+
+        # Must not raise — the shutdown contract swallows wipe errors and
+        # still runs core.shutdown() inside finally.
+        await plugin.shutdown()
+
+        await asyncio.sleep(0.2)
+        clients_after = await _count_redis_clients(redis_url_for_integration)
+        assert clients_after < clients_before, (
+            "core.shutdown() must run even when wipe raises — expected the "
+            f"Rust core's connection to be released (before={clients_before} after={clients_after})"
+        )

--- a/plugins/tests/rate_limiter/test_redis_integration.py
+++ b/plugins/tests/rate_limiter/test_redis_integration.py
@@ -1903,3 +1903,98 @@ class TestWipeOnDisable:
             "stale counter state — this is the user-visible promise of "
             "wipe-on-disable"
         )
+
+    @pytest.mark.asyncio
+    async def test_full_toggle_journey_across_multiple_instances(self, redis_url_for_integration):
+        """Multi-instance toggle journey: N plugins simulate the production fan-out.
+
+        At the cpex-plugins layer, "multiple gateway pods" and "multiple workers
+        per pod" collapse to a single knob — N independent plugin instances
+        sharing one Redis URL. This test runs N=3 concurrent instances, each
+        handling a different user, then drives the full enforce → disable →
+        re-enable cycle to assert:
+
+          * the parallel disable triggers exactly one wipe (the others skip via
+            the lock), and every ``rl:*`` key disappears;
+          * every user gets a fresh window after re-enable — not just the user
+            whose plugin happened to win the wipe race.
+
+        Test #5 (``test_wipe_is_idempotent_under_concurrent_shutdown``) already
+        proves N parallel shutdowns converge to a clean state, but with seeded
+        counters and no re-enable phase. The single-instance journey
+        (``test_full_toggle_journey_enforce_disable_reenforce``) proves the
+        transition composes, but with one plugin so the distributed lock isn't
+        exercised under realistic flow. This test is the composition of both —
+        real traffic-generated state across N instances, real distributed
+        coordination during the wipe, and the post-re-enable fresh-window
+        assertion across every user.
+
+        Window sized at 3/m for the same reason as the single-instance journey
+        — the test must never straddle a second boundary, so a passing Phase 3
+        request is unambiguous evidence of the wipe.
+        """
+        await _flush_redis(redis_url_for_integration)
+
+        users = ("alice", "bob", "carol")
+        payload = ToolPreInvokePayload(name="t", arguments={})
+
+        # ── Phase 1: enforce — all three instances saturate their users in parallel ──
+        plugins = [_make_redis_plugin(redis_url_for_integration, limit="3/m") for _ in users]
+        contexts = [
+            PluginContext(global_context=GlobalContext(request_id=f"r-{u}", user=u))
+            for u in users
+        ]
+
+        async def _saturate(plugin, ctx, user):
+            for i in range(3):
+                r = await plugin.tool_pre_invoke(payload, ctx)
+                assert r.continue_processing, f"{user}: request {i + 1}/3 must pass"
+            blocked = await plugin.tool_pre_invoke(payload, ctx)
+            assert blocked.continue_processing is False, (
+                f"{user}: 4th request must be blocked before disable"
+            )
+
+        await asyncio.gather(*(
+            _saturate(p, c, u) for p, c, u in zip(plugins, contexts, users)
+        ))
+
+        keys_pre_disable = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        for u in users:
+            assert any(u in k for k in keys_pre_disable), (
+                f"{u}'s counter key should exist before disable; got {keys_pre_disable}"
+            )
+
+        # ── Phase 2: parallel disable — exactly one wipes, all keys gone ──
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "disabled")
+
+        results = await asyncio.gather(
+            *(p.shutdown() for p in plugins),
+            return_exceptions=True,
+        )
+        for i, r in enumerate(results):
+            assert not isinstance(r, BaseException), (
+                f"plugin[{i}].shutdown() raised under concurrent toggle — got {r!r}"
+            )
+
+        keys_post_wipe = await _keys_in_redis(redis_url_for_integration, "rl:*")
+        assert keys_post_wipe == [], (
+            "concurrent shutdown under mode=disabled must converge to all rl:* "
+            f"keys deleted — expected [], got {keys_post_wipe}"
+        )
+
+        # ── Phase 3: re-enforce — every user gets a fresh window ──
+        # Fresh plugin instances mirror what each worker's plugin manager does
+        # on re-enable.
+        await _set_plugin_mode_key(redis_url_for_integration, "RateLimiter", "enforce")
+        fresh_plugins = [_make_redis_plugin(redis_url_for_integration, limit="3/m") for _ in users]
+
+        async def _first_request_passes(plugin, ctx, user):
+            r = await plugin.tool_pre_invoke(payload, ctx)
+            assert r.continue_processing, (
+                f"{user} was saturated pre-disable; after the wipe + re-enable, "
+                f"{user}'s first request must NOT be blocked"
+            )
+
+        await asyncio.gather(*(
+            _first_request_passes(p, c, u) for p, c, u in zip(fresh_plugins, contexts, users)
+        ))


### PR DESCRIPTION
## Summary

Closes [IBM/mcp-context-forge#4576](https://github.com/IBM/mcp-context-forge/issues/4576) — sub-issue of [#4514](https://github.com/IBM/mcp-context-forge/issues/4514) (rate-limiter runtime mode-toggle convergence).

When an operator flips the rate limiter to `mode: disabled` at runtime, the plugin now clears its accumulated counter state from Redis. Previously the counters survived the toggle, so an immediate re-enable (or a stale-mode worker still serving traffic) would block legitimate requests on counter values inherited from before the disable. After this change, `disabled` truly means "the limiter's effect is gone" — and re-enable starts every user with a fresh window.

Bumps `cpex_rate_limiter` 0.0.4 → 0.0.6.

---

## What changes

When `RateLimiterPlugin.shutdown()` runs, the plugin reads `plugin:<name>:mode` from Redis. If the value is `disabled`, the plugin acquires a distributed single-flight lock (`<prefix>-wipe-lock`, 30s TTL safety net), runs `SCAN + UNLINK` over its configured `redis_key_prefix`, and releases the lock. The wipe is bounded to keys under the plugin's configured prefix; nothing outside that namespace is touched.

The mechanism piggybacks on the framework's existing `reload_tenant` path: when `publish_plugin_mode_change("<name>", "disabled")` lands, every gateway worker's invalidation listener fires `factory.invalidate_all()` → `reload_tenant` per cached context → `manager.shutdown()` → `plugin.shutdown()`. Single-flight via the lock ensures the SCAN+UNLINK runs once across the cluster, even if N workers all process the broadcast simultaneously.

---

## Test coverage

`TestWipeOnDisable` class — 10 tests in `tests/rate_limiter/test_redis_integration.py`:

| Test | Target |
|---|---|
| `test_wipe_fires_when_mode_key_says_disabled` | Happy path |
| `test_no_wipe_when_mode_key_says_enforce` | Graceful pod restart safety |
| `test_no_wipe_when_mode_key_absent` | Fresh-deploy / no-mode-key safety |
| `test_no_wipe_when_redis_unreachable_for_mode_lookup` | Fail-safe on Redis outage |
| `test_wipe_is_idempotent_under_concurrent_shutdown` | 5-instance parallel shutdown converges |
| `test_core_shutdown_runs_even_when_wipe_raises` | Wipe failure doesn't leak Redis connections |
| `test_wipe_skipped_when_another_worker_holds_lock` | Distributed single-flight |
| `test_wipe_only_deletes_keys_under_configured_prefix` | Blast radius confined to configured prefix |
| `test_full_toggle_journey_enforce_disable_reenforce` | Single-instance journey: saturated user is no longer blocked after cycle |
| `test_full_toggle_journey_across_multiple_instances` | N=3 parallel instances: every user gets a fresh window after re-enable, not just the lock-winner's |

<details>
<summary>Full local gate</summary>

```text
cargo fmt -- --check                  clean
cargo clippy -- -D warnings           clean
make test-unit                        Rust tests: 58 passed
make test-integration                 pytest: 66 passed
```

</details>

---

## Deployment caveats (worth knowing before merge)

Two pre-conditions for the wipe path to actually fire — intrinsic properties of how the wipe interacts with the framework's plugin lifecycle, worth flagging so operators aren't surprised at start-up:

1. **Plugin must be loaded for the wipe to fire.** When `plugins/config.yaml` has `mode: "disabled"` for the plugin from startup, the framework loader does not instantiate the plugin under any cached manager. No plugin instance ⇒ no shutdown to fire ⇒ no wipe path to run, regardless of how many subscribers receive the broadcast. In practice this means: the wipe only takes effect after the plugin has been in `enforce` mode at least once.
2. **At least one cached manager required.** `factory.invalidate_all()` iterates only *cached* managers; a fresh gateway with zero traffic has zero cached managers. The first request through the gateway warms a manager; subsequent toggle broadcasts then have something to act on.

Neither caveat affects production deployments after the first request. Both are worth documenting on the rate-limiter README so operators understand the start-up timing.

---

## Migration notes

- **No new required config.** Existing deployments work unchanged. The wipe fires automatically on the disable transition.
- **`redis_key_prefix` is the blast-radius boundary.** If multiple rate-limiter instances share one Redis and use the same prefix, a disable on any one wipes counters for all. Default prefix is `"rl"`; operators with multiple limiters should set distinct prefixes.
