### PR TITLE
fix: narrow lockfile plugin CI selection

### DIFF
--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -1921,6 +1921,57 @@ class PluginCatalogTests(unittest.TestCase):
                 },
             )
 
+    def test_ci_selection_keeps_cargo_lock_with_plugin_change_plugin_scoped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            git = lambda *args: subprocess.run(  # noqa: E731
+                ["git", *args],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            git("init")
+            git("config", "user.name", "Test User")
+            git("config", "user.email", "test@example.com")
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/rate_limiter", "plugins/rust/python-package/pii_filter"]\n'
+            )
+            rate_limiter = self._create_plugin(root, "rate_limiter")
+            pii_filter = self._create_plugin(root, "pii_filter")
+            (rate_limiter / "src").mkdir()
+            (pii_filter / "src").mkdir()
+            (root / "Cargo.lock").write_text("# seed\n")
+            git("add", ".")
+            git("commit", "--no-verify", "-m", "seed layout")
+            base_sha = git("rev-parse", "HEAD").stdout.strip()
+
+            (rate_limiter / "src" / "lib.rs").write_text("// rate_limiter update\n")
+            (root / "Cargo.lock").write_text("# updated\n")
+            git("add", ".")
+            git("commit", "--no-verify", "-m", "plugin lockfile update")
+
+            result = run_catalog("ci-selection", str(root), "diff", base_sha, "HEAD")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["plugins"], ["rate_limiter"])
+            self.assertEqual(payload["cargo_packages"], ["rate_limiter"])
+            self.assertEqual(payload["plugin_count"], 1)
+
+            base_sha = git("rev-parse", "HEAD").stdout.strip()
+            (rate_limiter / "src" / "lib.rs").write_text("// rate_limiter update 2\n")
+            (pii_filter / "src" / "lib.rs").write_text("// pii_filter update\n")
+            (root / "Cargo.lock").write_text("# updated again\n")
+            git("add", ".")
+            git("commit", "--no-verify", "-m", "multi-plugin lockfile update")
+
+            result = run_catalog("ci-selection", str(root), "diff", base_sha, "HEAD")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["plugins"], ["pii_filter", "rate_limiter"])
+            self.assertEqual(payload["cargo_packages"], ["pii_filter", "rate_limiter"])
+            self.assertEqual(payload["plugin_count"], 2)
+
     def test_ci_selection_treats_deny_config_change_as_all_plugins(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -23,7 +23,6 @@ SHARED_PATH_PREFIXES = (
     ".config/",
     ".github/workflows/",
     "Cargo.toml",
-    "Cargo.lock",
     "deny.toml",
     "crates/",
     "README.md",
@@ -520,10 +519,12 @@ def _changed_plugins_for_records(
     root: Path, plugins: list[PluginRecord], changed_paths: list[str]
 ) -> list[str]:
     plugin_lookup = {record.slug: record for record in plugins}
+    normalized_changed_paths = [path.removeprefix("./") for path in changed_paths]
+    changed_path_set = set(normalized_changed_paths)
 
     if any(
         path == prefix.rstrip("/") or path.startswith(prefix)
-        for path in changed_paths
+        for path in normalized_changed_paths
         for prefix in SHARED_PATH_PREFIXES
     ):
         return sorted(plugin_lookup)
@@ -531,7 +532,10 @@ def _changed_plugins_for_records(
     changed: set[str] = set()
     managed_prefix = f"{MANAGED_ROOT.as_posix()}/"
     integration_prefix = "plugins/tests/"
-    for path in changed_paths:
+    has_lockfile_change = "Cargo.lock" in changed_path_set
+    for path in normalized_changed_paths:
+        if path == "Cargo.lock":
+            continue
         if not path.startswith(managed_prefix):
             if not path.startswith(integration_prefix):
                 continue
@@ -544,6 +548,8 @@ def _changed_plugins_for_records(
         slug = relative.split("/", maxsplit=1)[0]
         if slug in plugin_lookup:
             changed.add(slug)
+    if has_lockfile_change and not changed:
+        return sorted(plugin_lookup)
     return sorted(changed)
 
 


### PR DESCRIPTION
## Summary

- keep `Cargo.lock` from forcing all plugins when plugin-specific paths identify the changed plugin set
- preserve conservative all-plugin selection for lockfile-only changes
- add regression coverage for `Cargo.lock` plus one plugin path

Fixes #80

## Validation

- `python3 -m unittest tests.test_plugin_catalog.PluginCatalogTests.test_ci_selection_treats_cargo_lock_change_as_all_plugins tests.test_plugin_catalog.PluginCatalogTests.test_ci_selection_keeps_cargo_lock_with_plugin_change_plugin_scoped`
- `python3 tools/plugin_catalog.py validate .`
- `python3 tools/plugin_catalog.py ci-selection . diff a028daee84c0879bda1a38b59111afecbf044b87 c628d106327bf595c024d7fe515abcab7d7ff903`
