### PR TITLE
Remove stale install wheel release validation

### DIFF
--- a/.github/workflows/ci-install-built-wheel.yaml
+++ b/.github/workflows/ci-install-built-wheel.yaml
@@ -41,12 +41,3 @@ jobs:
 
       - name: Run install-built-wheel tests
         run: python3 -m unittest tests/test_install_built_wheel.py
-
-  release-validation:
-    if: github.event_name == 'pull_request'
-    needs: test
-    uses: ./.github/workflows/release-rust-python-package.yaml
-    with:
-      tag: retry-with-backoff-v0.3.0
-      repository: testpypi
-      publish_enabled: false


### PR DESCRIPTION
## Summary
- remove the redundant release-validation job from CI Install Built Wheel
- keep the workflow focused on tests/test_install_built_wheel.py

## Why
The removed job hardcoded a real release tag, so plugin version bumps required unrelated CI edits. Release validation already runs in CI Rust Python Package Plugins with detected plugin versions.

## Validation
- python3 -m unittest tests/test_install_built_wheel.py
- parsed .github/workflows/ci-install-built-wheel.yaml with PyYAML