### PR TITLE
Added Detect Secrets to the project

### DIFF
--- a/.github/workflows/ci-detect-secrets.yaml
+++ b/.github/workflows/ci-detect-secrets.yaml
@@ -1,0 +1,59 @@
+name: CI Detect Secrets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".pre-commit-config.yaml"
+      - ".secrets.baseline"
+      - "Makefile"
+      - "DEVELOPING.md"
+      - ".github/workflows/ci-detect-secrets.yaml"
+      - ".github/workflows/ci-rust-python-package.yaml"
+      - "plugins/**"
+      - "crates/**"
+      - "tools/**"
+      - "tests/**"
+      - "*.md"
+      - "*.toml"
+      - "*.yaml"
+      - "*.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".pre-commit-config.yaml"
+      - ".secrets.baseline"
+      - "Makefile"
+      - "DEVELOPING.md"
+      - ".github/workflows/ci-detect-secrets.yaml"
+      - ".github/workflows/ci-rust-python-package.yaml"
+      - "plugins/**"
+      - "crates/**"
+      - "tools/**"
+      - "tests/**"
+      - "*.md"
+      - "*.toml"
+      - "*.yaml"
+      - "*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: python -m pip install uv==0.9.30
+      - name: Run detect-secrets
+        run: |
+          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 scan \
+            --update .secrets.baseline \
+            --use-all-plugins \
+            --exclude-files '(^\.secrets\.baseline$|package-lock\.json$|Cargo\.lock$|uv\.lock$|go\.sum$|poetry\.lock$|Pipfile\.lock$)'
+          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 audit --report --fail-on-unaudited .secrets.baseline

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -111,7 +111,6 @@ jobs:
             echo "has_release_validation_tags=${has_release_validation_tags}"
           } >> "$GITHUB_OUTPUT"
 
-
   build-test:
     needs: validate-and-detect
     if: needs.validate-and-detect.outputs.has_plugins == 'true'

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -111,22 +111,6 @@ jobs:
             echo "has_release_validation_tags=${has_release_validation_tags}"
           } >> "$GITHUB_OUTPUT"
 
-  detect-secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        run: python -m pip install uv==0.9.30
-      - name: Run detect-secrets
-        run: |
-          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 scan \
-            --use-all-plugins \
-            --exclude-files '(^\.secrets\.baseline$|package-lock\.json$|Cargo\.lock$|uv\.lock$|go\.sum$|poetry\.lock$|Pipfile\.lock$)' \
-            --update .secrets.baseline
-          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 audit --report --fail-on-unaudited .secrets.baseline
 
   build-test:
     needs: validate-and-detect

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -111,6 +111,23 @@ jobs:
             echo "has_release_validation_tags=${has_release_validation_tags}"
           } >> "$GITHUB_OUTPUT"
 
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: python -m pip install uv==0.9.30
+      - name: Run detect-secrets
+        run: |
+          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 scan \
+            --use-all-plugins \
+            --exclude-files '(^\.secrets\.baseline$|package-lock\.json$|Cargo\.lock$|uv\.lock$|go\.sum$|poetry\.lock$|Pipfile\.lock$)' \
+            --update .secrets.baseline
+          uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 audit --report --fail-on-unaudited .secrets.baseline
+
   build-test:
     needs: validate-and-detect
     if: needs.validate-and-detect.outputs.has_plugins == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,23 @@ repos:
       - id: mixed-line-ending
         args: [--fix=lf]
       - id: trailing-whitespace
+
+  - repo: https://github.com/ibm/detect-secrets
+    rev: 076672a9a01abdfc7ecee2e7d14f08cdccb73976
+    hooks:
+      - id: detect-secrets
+        args:
+          - '--baseline'
+          - '.secrets.baseline'
+          - --use-all-plugins
+          - --fail-on-unaudited
+        exclude: |
+          (?x)(
+            ^\.secrets\.baseline$
+            |package-lock\.json$
+            |Cargo\.lock$
+            |uv\.lock$
+            |go\.sum$
+            |poetry\.lock$
+            |Pipfile\.lock$
+          )

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,372 @@
+{
+  "exclude": {
+    "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)",
+    "lines": null
+  },
+  "generated_at": "2026-05-21T12:19:43Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "plugins/rust/python-package/encoded_exfil_detection/src/lib.rs": [
+      {
+        "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_verified": false,
+        "line_number": 573,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "d7da4707f9793b357da965eb04f06ceae7d7bfa6",
+        "is_verified": false,
+        "line_number": 574,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "0962e90797cdf7ff77c8a0a9477a7ca4f493465f",
+        "is_verified": false,
+        "line_number": 892,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "ca3f3092640b07c051f03e52690fda1bcee3f60d",
+        "is_verified": false,
+        "line_number": 913,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "532fdeccb155dce5b528ba039b9a5d201b817e3b",
+        "is_verified": false,
+        "line_number": 932,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_verified": false,
+        "line_number": 969,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "ff1a7ebc241b8eefe9e75e13f20cc22c365ab626",
+        "is_verified": false,
+        "line_number": 969,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/rust/python-package/secrets_detection/benches/secrets_detection.rs": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/rust/python-package/secrets_detection/src/plugin.rs": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 585,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/rust/python-package/secrets_detection/src/scanner.rs": [
+      {
+        "hashed_secret": "078553dc10635837abb80f404302c70cba91b879",
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_verified": false,
+        "line_number": 145,
+        "type": "GitHub Token",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "97d99a51e5ac827bb36fe6273facfda35245917a",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Private Key",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "b1775a785f09a6ebaf2dc33d6eaeb98974d9cdb8",
+        "is_verified": false,
+        "line_number": 175,
+        "type": "Hex High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "eae9124e42e2ef05ba727bd1a1c0c6fa61a05b9e",
+        "is_verified": false,
+        "line_number": 197,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 220,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "9d7235fe33b6612ed7ebca4b63afd00d4adf5d66",
+        "is_verified": false,
+        "line_number": 274,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "356bcfac838d811d3c26b4c46025dc87cff866c2",
+        "is_verified": false,
+        "line_number": 305,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 1227,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/encoded_exfil_detection/test_integration.py": [
+      {
+        "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
+        "is_verified": false,
+        "line_number": 145,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_verified": false,
+        "line_number": 487,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
+        "is_verified": false,
+        "line_number": 526,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
+        "is_verified": false,
+        "line_number": 539,
+        "type": "Base64 High Entropy String",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
+        "is_verified": false,
+        "line_number": 894,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
+        "is_verified": false,
+        "line_number": 1097,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/secrets_detection/test_hook_dispatch.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 228,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/secrets_detection/test_hook_smoke.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 208,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/secrets_detection/test_plugin_hook_results.py": [
+      {
+        "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 322,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/secrets_detection/test_plugin_hooks.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 187,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ],
+    "plugins/tests/secrets_detection/test_public_rust_api.py": [
+      {
+        "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
+        "is_verified": false,
+        "line_number": 415,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
+        "is_verified": false,
+        "line_number": 510,
+        "type": "Secret Keyword",
+        "verified_result": null,
+        "is_secret": false
+      },
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_verified": false,
+        "line_number": 862,
+        "type": "AWS Access Key",
+        "verified_result": null,
+        "is_secret": false
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.64.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -56,6 +56,27 @@ make plugin-test PLUGIN=pii_filter
 It runs the catalog validator plus the shared repo contract test modules:
 `tests/test_plugin_catalog.py` and `tests/test_install_built_wheel.py`.
 
+## Secret Detection
+
+IBM detect-secrets helps prevent accidental credential commits.
+
+**Scan and audit:**
+```bash
+make detect-secrets-scan
+make detect-secrets-audit
+```
+
+**Local check:**
+```bash
+pre-commit run detect-secrets --all-files
+# or
+make detect-secrets-check
+```
+
+**CI:** Pull request checks fail on unaudited secrets. Audit findings locally before pushing.
+
+**Baseline:** `.secrets.baseline` stores audited findings and must be committed after baseline changes.
+
 ## Adding a New Managed Plugin
 
 ### Using the Plugin Scaffold Generator (Recommended)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-.PHONY: help plugins-list plugins-validate plugin-test plugin-mutants plugin-mutants-list plugin-scaffold plugin-scaffold-help
+DETECT_SECRETS_SPEC := git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976
+
+.PHONY: help plugins-list plugins-validate plugin-test plugin-mutants plugin-mutants-list plugin-scaffold plugin-scaffold-help detect-secrets-scan detect-secrets-audit detect-secrets-check
 
 help:
-	@printf "plugins-list\nplugins-validate\nplugin-test PLUGIN=<slug>\nplugin-mutants PLUGIN=<slug>\nplugin-mutants-list PLUGIN=<slug>\nplugin-scaffold\nplugin-scaffold-help\n"
+	@printf "plugins-list\nplugins-validate\nplugin-test PLUGIN=<slug>\nplugin-mutants PLUGIN=<slug>\nplugin-mutants-list PLUGIN=<slug>\nplugin-scaffold\nplugin-scaffold-help\ndetect-secrets-scan\ndetect-secrets-audit\ndetect-secrets-check\n"
 
 plugins-list:
 	@python3 tools/plugin_catalog.py list .
@@ -9,6 +11,18 @@ plugins-list:
 plugins-validate:
 	@python3 tools/plugin_catalog.py validate .
 	@python3 -m unittest tests/test_plugin_catalog.py tests/test_install_built_wheel.py
+
+detect-secrets-scan:  ## Regenerate secrets baseline
+	@uv tool run $(DETECT_SECRETS_SPEC) scan \
+		--update .secrets.baseline \
+		--use-all-plugins
+
+detect-secrets-audit:  ## Audit secrets baseline interactively
+	@test -f .secrets.baseline || (echo "Run make detect-secrets-scan first" && exit 1)
+	@uv tool run $(DETECT_SECRETS_SPEC) audit .secrets.baseline
+
+detect-secrets-check:  ## Verify no unaudited secrets (CI equivalent)
+	@pre-commit run detect-secrets --all-files
 
 plugin-test:
 	@test -n "$(PLUGIN)" || (echo "Set PLUGIN=<slug>" && exit 1)


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
_Link to the epic or parent issue:_
Closes #67

---

## 🚀 Summary (1-2 sentences)
_What does this PR add or change?_

Adds IBM detect-secrets scanning to this repo across local tooling and GitHub CI. Introduces an audited `.secrets.baseline`, Makefile helpers, pre-commit integration, a dedicated repo-level secret scanning workflow, and developer docs.

---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)
_Design sketch, screenshots, or extra context._

- Added IBM detect-secrets hook to `.pre-commit-config.yaml` pinned to `076672a9a01abdfc7ecee2e7d14f08cdccb73976`
- Added Makefile targets:
  - `detect-secrets-scan`
  - `detect-secrets-audit`
  - `detect-secrets-check`
- Added dedicated repo-level workflow: `.github/workflows/ci-detect-secrets.yaml`
- Removed detect-secrets job from `.github/workflows/ci-rust-python-package.yaml`
- Generated and audited `.secrets.baseline`
- Documented local workflow in `DEVELOPING.md`

Implementation note:
- Pinned IBM fork CLI uses `scan --update .secrets.baseline --use-all-plugins`
- CI enforcement uses `audit --report --fail-on-unaudited .secrets.baseline`

Validation completed:
- `uv tool run git+https://github.com/ibm/detect-secrets.git@076672a9a01abdfc7ecee2e7d14f08cdccb73976 audit --report --fail-on-unaudited .secrets.baseline` passes

Local environment note:
- `pre-commit` was not installed in this shell, so `pre-commit run detect-secrets --all-files` and `make detect-secrets-check` could not be executed here even though configuration is in place.

If the change introduces or alters an architectural decision, add or update an ADR in **`docs/docs/adr/`** and link it here._

```mermaid
flowchart TD
    A[Developer commit or PR] --> B[pre-commit detect-secrets]
    B --> C[.secrets.baseline]
    C --> D[CI Detect Secrets workflow]
    D --> E[Fail on unaudited findings]
```