### PR TITLE
fix: dispatch release workflow after tag creation

### DIFF
--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -437,6 +437,8 @@ jobs:
             gh workflow run release-rust-python-package.yaml \
               --ref main \
               -f "tag=${tag}" \
-              -f repository=pypi
-            echo "Dispatched PyPI release workflow for ${tag}."
+              -f repository=pypi \
+              -f publish_enabled=true
+            release_run_url="$(gh run list -w release-rust-python-package.yaml --limit 1 --json url --jq '.[0].url')"
+            echo "Dispatched PyPI release workflow for ${tag}: ${release_run_url}"
           done < <(python3 -c 'import json, os; [print(tag) for tag in json.loads(os.environ["RELEASE_TAGS"])]')

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -405,6 +405,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -413,6 +414,7 @@ jobs:
 
       - name: Create release tags for bumped plugin versions
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAGS: ${{ needs.validate-and-detect.outputs.release_validation_tags }}
         run: |
           set -euo pipefail
@@ -432,23 +434,9 @@ jobs:
                 exit 1
               fi
             }
+            gh workflow run release-rust-python-package.yaml \
+              --ref main \
+              -f "tag=${tag}" \
+              -f repository=pypi
+            echo "Dispatched PyPI release workflow for ${tag}."
           done < <(python3 -c 'import json, os; [print(tag) for tag in json.loads(os.environ["RELEASE_TAGS"])]')
-
-  publish-release-tags:
-    needs:
-      - validate-and-detect
-      - create-release-tags
-    if: needs.create-release-tags.result == 'success' && needs.validate-and-detect.outputs.release_validation_tags != '[]'
-    strategy:
-      fail-fast: false
-      matrix:
-        tag: ${{ fromJson(needs.validate-and-detect.outputs.release_validation_tags || '[]') }}
-    permissions:
-      contents: read
-      id-token: write
-    secrets: inherit
-    uses: ./.github/workflows/release-rust-python-package.yaml
-    with:
-      tag: ${{ matrix.tag }}
-      repository: pypi
-      publish_enabled: true

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -33,6 +33,11 @@ on:
         options:
           - testpypi
           - pypi
+      publish_enabled:
+        description: "Whether to run the publish job"
+        required: false
+        default: true
+        type: boolean
 permissions:
   contents: read
 

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2825,9 +2825,6 @@ class PluginCatalogTests(unittest.TestCase):
         create_tags_section = self._extract_workflow_job_section(
             workflow, "create-release-tags"
         )
-        publish_tags_section = self._extract_workflow_job_section(
-            workflow, "publish-release-tags"
-        )
         release_validation_section = self._extract_workflow_job_section(
             workflow, "release-validation"
         )
@@ -2900,6 +2897,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("needs.documentation.result == 'success'", create_tags_section)
         self.assertIn("needs.mutation-testing.result == 'skipped'", create_tags_section)
         self.assertIn("needs.release-validation.result == 'skipped'", create_tags_section)
+        self.assertIn("actions: write", create_tags_section)
         self.assertIn("contents: write", create_tags_section)
         # Keep the tag loop out of a pipeline so bash exits on failures inside the loop.
         self.assertNotIn("mapfile", create_tags_section)
@@ -2907,16 +2905,12 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn('[[ ! "${tag}" =~ ^[a-zA-Z0-9._-]+$ ]]', create_tags_section)
         self.assertIn('git tag "${tag}" "${GITHUB_SHA}"', create_tags_section)
         self.assertIn('git push origin "refs/tags/${tag}"', create_tags_section)
-        self.assertIn(
-            "needs.create-release-tags.result == 'success' && needs.validate-and-detect.outputs.release_validation_tags != '[]'",
-            publish_tags_section,
-        )
-        self.assertIn("tag: ${{ fromJson(needs.validate-and-detect.outputs.release_validation_tags || '[]') }}", publish_tags_section)
-        self.assertIn("repository: pypi", publish_tags_section)
-        self.assertIn("publish_enabled: true", publish_tags_section)
-        self.assertIn("id-token: write", publish_tags_section)
-        self.assertIn("secrets: inherit", publish_tags_section)
-        self.assertIn("uses: ./.github/workflows/release-rust-python-package.yaml", publish_tags_section)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", create_tags_section)
+        self.assertIn("gh workflow run release-rust-python-package.yaml", create_tags_section)
+        self.assertIn("--ref main", create_tags_section)
+        self.assertIn('-f "tag=${tag}"', create_tags_section)
+        self.assertIn("-f repository=pypi", create_tags_section)
+        self.assertNotIn("publish-release-tags:", workflow)
         self.assertNotIn("cargo-audit", security_section)
         self.assertNotIn("cargo audit", security_section)
         self.assertIn("cargo install cargo-deny", security_section)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2910,6 +2910,13 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("--ref main", create_tags_section)
         self.assertIn('-f "tag=${tag}"', create_tags_section)
         self.assertIn("-f repository=pypi", create_tags_section)
+        self.assertIn("-f publish_enabled=true", create_tags_section)
+        self.assertIn("gh run list -w release-rust-python-package.yaml", create_tags_section)
+        self.assertIn("--json url --jq '.[0].url'", create_tags_section)
+        self.assertLess(
+            create_tags_section.index('git push origin "refs/tags/${tag}"'),
+            create_tags_section.index("gh workflow run release-rust-python-package.yaml"),
+        )
         self.assertNotIn("publish-release-tags:", workflow)
         self.assertNotIn("cargo-audit", security_section)
         self.assertNotIn("cargo audit", security_section)
@@ -3477,6 +3484,8 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("workflow_call:", workflow)
         self.assertIn("publish_enabled:", workflow)
         self.assertIn('default: false', workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn('default: true', workflow)
         self.assertIn('git fetch --force origin "refs/heads/main:refs/remotes/origin/main"', workflow)
         self.assertIn('if git merge-base --is-ancestor "${tag_ref}" "refs/remotes/origin/main"; then', workflow)
         self.assertIn("tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}", workflow)


### PR DESCRIPTION
## Summary

- Fixes #102.
- Dispatches `release-rust-python-package.yaml` explicitly after merge-to-main release tags are created.
- Grants the tag creation job `actions: write` so `gh workflow run` can start the PyPI release workflow.
- Removes the skipped `publish-release-tags` reusable job path and covers the new behavior in the catalog workflow test.

## Verification

- `actionlint .github/workflows/ci-rust-python-package.yaml`
- `python3 tools/plugin_catalog.py validate .`
- `python3 -m unittest tests.test_plugin_catalog`
- `git diff --check`