### PR TITLE
Fix padded base64 secret detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,7 +1694,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets_detection"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/plugins/rust/python-package/secrets_detection/Cargo.toml
+++ b/plugins/rust/python-package/secrets_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secrets_detection"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect likely credentials and secrets in prompt input, tool output, and resource content"
 author: "ContextForge Contributors"
-version: "0.3.3"
+version: "0.3.4"
 kind: "cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -60,7 +60,10 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     );
     patterns.insert(
         "base64_24",
-        Regex::new(r"\b[A-Za-z0-9+/]{24,}={0,2}\b").expect("valid base64_24 regex"),
+        Regex::new(
+            r"(?:^|[^A-Za-z0-9+/])((?:[A-Za-z0-9+/]{24,}={0,2}|[A-Za-z0-9+/]{22}==|[A-Za-z0-9+/]{23}=))(?:$|[^A-Za-z0-9+/=])",
+        )
+            .expect("valid base64_24 regex"),
     );
     patterns
 });

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -315,4 +315,21 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn redacts_padded_base64_secret_without_leaving_padding() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            redact: true,
+            redaction_text: "[REDACTED]".to_string(),
+            ..Default::default()
+        };
+
+        let sample = ["mZ8qL2vYwT1p", "Nc4Rb6HxUg", "=="].concat();
+        let (findings, redacted) = detect_and_redact(&format!("token={sample}"), &config);
+
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].pii_type, "base64_24");
+        assert_eq!(redacted, "token=[REDACTED]");
+    }
 }

--- a/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
@@ -25,13 +25,27 @@ pub fn detect_and_redact(text: &str, config: &SecretsDetectionConfig) -> (Vec<Fi
             continue;
         }
 
-        for matched in pattern.find_iter(text) {
-            candidates.push(MatchCandidate {
-                name,
-                start: matched.start(),
-                end: matched.end(),
-                text: matched.as_str(),
-            });
+        if *name == "base64_24" {
+            for captures in pattern.captures_iter(text) {
+                let Some(matched) = captures.get(1) else {
+                    continue;
+                };
+                candidates.push(MatchCandidate {
+                    name,
+                    start: matched.start(),
+                    end: matched.end(),
+                    text: matched.as_str(),
+                });
+            }
+        } else {
+            for matched in pattern.find_iter(text) {
+                candidates.push(MatchCandidate {
+                    name,
+                    start: matched.start(),
+                    end: matched.end(),
+                    text: matched.as_str(),
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix base64_24 detection for values ending with padding
- redact only the captured base64 value so delimiters stay intact
- add regression coverage for padded base64 redaction
- bump cpex-secrets-detection to 0.3.4

## Tests
- cargo test -p secrets_detection
- make check-all
- make test-integration