### PR TITLE
Fix payload policy mutation regressions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)",
     "lines": null
   },
-  "generated_at": "2026-05-28T14:43:19Z",
+  "generated_at": "2026-05-29T09:01:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -98,7 +98,7 @@
         "hashed_secret": "0962e90797cdf7ff77c8a0a9477a7ca4f493465f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 895,
+        "line_number": 951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -106,7 +106,7 @@
         "hashed_secret": "ca3f3092640b07c051f03e52690fda1bcee3f60d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 916,
+        "line_number": 972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -114,7 +114,7 @@
         "hashed_secret": "532fdeccb155dce5b528ba039b9a5d201b817e3b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 935,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -122,7 +122,7 @@
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 972,
+        "line_number": 1028,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -130,7 +130,7 @@
         "hashed_secret": "ff1a7ebc241b8eefe9e75e13f20cc22c365ab626",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 972,
+        "line_number": 1028,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)",
     "lines": null
   },
-  "generated_at": "2026-05-21T12:19:43Z",
+  "generated_at": "2026-05-28T14:43:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -80,287 +80,287 @@
     "plugins/rust/python-package/encoded_exfil_detection/src/lib.rs": [
       {
         "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 573,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d7da4707f9793b357da965eb04f06ceae7d7bfa6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 574,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0962e90797cdf7ff77c8a0a9477a7ca4f493465f",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 892,
+        "line_number": 895,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ca3f3092640b07c051f03e52690fda1bcee3f60d",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 913,
+        "line_number": 916,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "532fdeccb155dce5b528ba039b9a5d201b817e3b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 932,
+        "line_number": 935,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 969,
+        "line_number": 972,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ff1a7ebc241b8eefe9e75e13f20cc22c365ab626",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 969,
+        "line_number": 972,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/rust/python-package/secrets_detection/benches/secrets_detection.rs": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/rust/python-package/secrets_detection/src/plugin.rs": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 585,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/rust/python-package/secrets_detection/src/scanner.rs": [
       {
         "hashed_secret": "078553dc10635837abb80f404302c70cba91b879",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 145,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 145,
         "type": "GitHub Token",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "97d99a51e5ac827bb36fe6273facfda35245917a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 149,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 167,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "b1775a785f09a6ebaf2dc33d6eaeb98974d9cdb8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 175,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "eae9124e42e2ef05ba727bd1a1c0c6fa61a05b9e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 197,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 220,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9d7235fe33b6612ed7ebca4b63afd00d4adf5d66",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 274,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "356bcfac838d811d3c26b4c46025dc87cff866c2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 305,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1227,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/encoded_exfil_detection/test_integration.py": [
       {
         "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 147,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 487,
+        "line_number": 549,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 526,
+        "line_number": 588,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 601,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 894,
+        "line_number": 956,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 1097,
+        "line_number": 1159,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_hook_dispatch.py": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 228,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_hook_smoke.py": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 208,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_plugin_hook_results.py": [
       {
         "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 106,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 322,
+        "line_number": 384,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_plugin_hooks.py": [
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 230,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_public_rust_api.py": [
       {
         "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 415,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 510,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 862,
         "type": "AWS Access Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ]
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoded_exfil_detection"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64",
  "cpex_framework_bridge",

--- a/plugins/rust/python-package/encoded_exfil_detection/Cargo.toml
+++ b/plugins/rust/python-package/encoded_exfil_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "encoded_exfil_detection"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/encoded_exfil_detection/cpex_encoded_exfil_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/encoded_exfil_detection/cpex_encoded_exfil_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect suspicious encoded payload exfiltration patterns in prompts, tool outputs, and resources"
 author: "ContextForge Contributors"
-version: "0.3.2"
+version: "0.3.3"
 kind: "cpex_encoded_exfil_detection.encoded_exfil_detection.EncodedExfilDetectorPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/encoded_exfil_detection/src/lib.rs
+++ b/plugins/rust/python-package/encoded_exfil_detection/src/lib.rs
@@ -871,6 +871,9 @@ define_stub_info_gatherer!(stub_info);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CString;
+
+    use pyo3::types::PyModule;
 
     #[test]
     fn test_scan_text_detects_base64_sensitive_payload() {
@@ -882,6 +885,59 @@ mod tests {
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].encoding, "base64");
         assert!(findings[0].score >= cfg.min_suspicion_score);
+    }
+
+    #[test]
+    fn test_scan_container_detects_mapping_wrapper_values() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let code = CString::new(
+                r#"
+from collections.abc import Mapping
+
+class MappingWrapper(Mapping):
+    def __init__(self, original):
+        self._original = original
+
+    def __getitem__(self, key):
+        return self._original[key]
+
+    def __iter__(self):
+        return iter(self._original)
+
+    def __len__(self):
+        return len(self._original)
+
+    def items(self):
+        return [(key, self[key]) for key in self._original]
+"#,
+            )
+            .unwrap();
+            let module =
+                PyModule::from_code(py, code.as_c_str(), c"test_module.py", c"test_module")?;
+            let original = PyDict::new(py);
+            let sensitive = [b"api_".as_slice(), b"key=super-secret-token-value"].concat();
+            let encoded = STANDARD.encode(sensitive);
+            original.set_item("message", encoded)?;
+            let payload = module.getattr("MappingWrapper")?.call1((original,))?;
+            let cfg = DetectorConfig {
+                redact: true,
+                redaction_text: "[ENCODED]".to_string(),
+                ..DetectorConfig::default()
+            };
+
+            let (count, redacted, findings) = scan_container(py, &payload, "", &cfg, 0)?;
+
+            assert_eq!(count, 1);
+            assert_eq!(findings.len(), 1);
+            assert_eq!(
+                redacted.get_item("message")?.extract::<String>()?,
+                "[ENCODED]"
+            );
+
+            Ok(())
+        })
+        .unwrap();
     }
 
     #[test]

--- a/plugins/rust/python-package/encoded_exfil_detection/src/lib.rs
+++ b/plugins/rust/python-package/encoded_exfil_detection/src/lib.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use base64::engine::general_purpose::{STANDARD, URL_SAFE};
 use pyo3::prelude::*;
-use pyo3::types::{PyAny, PyDict, PyList, PyString};
+use pyo3::types::{PyAny, PyDict, PyList, PyMapping, PyString, PyTuple};
 use pyo3_stub_gen::define_stub_info_gatherer;
 use pyo3_stub_gen::derive::*;
 use regex::Regex;
@@ -756,12 +756,15 @@ fn scan_container<'py>(
         ));
     }
 
-    if let Ok(dict) = container.cast::<PyDict>() {
+    if let Ok(mapping) = container.cast::<PyMapping>() {
         let new_dict = PyDict::new(py);
         let all_findings = PyList::empty(py);
         let mut total = 0usize;
 
-        for (key, value) in dict.iter() {
+        for item in mapping.items()?.iter() {
+            let item = item.cast::<PyTuple>()?;
+            let key = item.get_item(0)?;
+            let value = item.get_item(1)?;
             let key_str = key.str()?.to_string_lossy().into_owned();
             let child_path = if path.is_empty() {
                 key_str.clone()

--- a/plugins/tests/encoded_exfil_detection/test_integration.py
+++ b/plugins/tests/encoded_exfil_detection/test_integration.py
@@ -327,7 +327,7 @@ class TestEncodedExfilPluginHooks:
         for ex in examples:
             assert set(ex.keys()) == {"encoding", "path", "score"}
 
-    async def test_resource_post_fetch_redaction_survives_cpex_policy(self):
+    async def test_resource_post_fetch_redaction_survives_cpex_policy_with_isolated_payload(self):
         plugin = self._plugin({"block_on_detection": False, "redact": True, "redaction_text": "[ENCODED]"})
         encoded = base64.b64encode(b"api_key=super-secret").decode()
         payload = ResourcePostFetchPayload(uri="file:///tmp/data.txt", content={"text": encoded})

--- a/plugins/tests/encoded_exfil_detection/test_integration.py
+++ b/plugins/tests/encoded_exfil_detection/test_integration.py
@@ -23,6 +23,8 @@ from cpex.framework import (
     ToolHookType,
     ToolPostInvokePayload,
 )
+from cpex.framework.hooks.policies import HookPayloadPolicy, apply_policy
+from cpex.framework.memory import wrap_payload_for_isolation
 
 from cpex_encoded_exfil_detection.encoded_exfil_detection import (
     _prefix_finding_paths,
@@ -226,6 +228,25 @@ class TestEncodedExfilPluginHooks:
         assert result.metadata is not None
         assert result.metadata.get("encoded_exfil_redacted") is True
 
+    async def test_prompt_pre_fetch_redaction_survives_cpex_policy_with_isolated_payload(self):
+        plugin = self._plugin({"block_on_detection": False, "redact": True, "redaction_text": "[ENCODED]"})
+        encoded = base64.b64encode(b"api_key=super-secret").decode()
+        payload = PromptPrehookPayload(prompt_id="prompt-1", args={"input": encoded})
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.prompt_pre_fetch(plugin_input, self._context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"args"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert payload.args["input"] == encoded
+        assert filtered.args["input"] == "[ENCODED]"
+
     async def test_tool_post_invoke_blocks(self):
         plugin = self._plugin({"block_on_detection": True})
         encoded_hex = b"password=this-should-not-leave".hex()
@@ -249,6 +270,28 @@ class TestEncodedExfilPluginHooks:
         assert result.modified_payload.result["message"] == "***BLOCKED***"
         assert result.metadata is not None
         assert result.metadata.get("encoded_exfil_redacted") is True
+
+    async def test_tool_post_invoke_redaction_survives_cpex_policy_with_isolated_payload(self):
+        plugin = self._plugin({"block_on_detection": False, "redact": True, "redaction_text": "***BLOCKED***"})
+        encoded = base64.b64encode(b"client_secret=ultra-secret").decode()
+        payload = ToolPostInvokePayload(
+            name="generator",
+            result={"content": [{"type": "text", "text": encoded}], "isError": False},
+        )
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.tool_post_invoke(plugin_input, self._context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"result"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert payload.result["content"][0]["text"] == encoded
+        assert filtered.result["content"][0]["text"] == "***BLOCKED***"
 
     async def test_tool_post_invoke_clean_payload(self):
         plugin = self._plugin({"block_on_detection": True})
@@ -283,6 +326,25 @@ class TestEncodedExfilPluginHooks:
         examples = result.violation.details["examples"]
         for ex in examples:
             assert set(ex.keys()) == {"encoding", "path", "score"}
+
+    async def test_resource_post_fetch_redaction_survives_cpex_policy(self):
+        plugin = self._plugin({"block_on_detection": False, "redact": True, "redaction_text": "[ENCODED]"})
+        encoded = base64.b64encode(b"api_key=super-secret").decode()
+        payload = ResourcePostFetchPayload(uri="file:///tmp/data.txt", content={"text": encoded})
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.resource_post_fetch(plugin_input, self._context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"content"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert payload.content["text"] == encoded
+        assert filtered.content["text"] == "[ENCODED]"
 
 
 class TestEncodedExfilHelpers:

--- a/plugins/tests/secrets_detection/test_plugin_hook_results.py
+++ b/plugins/tests/secrets_detection/test_plugin_hook_results.py
@@ -325,7 +325,7 @@ class TestPluginHookResults:
         assert result.modified_payload.content.text == "SLACK_TOKEN=[REDACTED]"
         assert result.metadata == {"secrets_redacted": True, "count": 1}
 
-    async def test_resource_post_fetch_redaction_survives_cpex_policy(self, plugin):
+    async def test_resource_post_fetch_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
         payload = ResourcePostFetchPayload(
             uri="file:///tmp/secret.txt",
             content=ResourceContent(

--- a/plugins/tests/secrets_detection/test_plugin_hook_results.py
+++ b/plugins/tests/secrets_detection/test_plugin_hook_results.py
@@ -1,5 +1,8 @@
 import pytest
 
+from cpex.framework.hooks.policies import HookPayloadPolicy, apply_policy
+from cpex.framework.memory import wrap_payload_for_isolation
+
 from secrets_detection.helpers import *  # noqa: F403,F405
 
 
@@ -33,6 +36,37 @@ class TestPluginHookResults:
         )
         assert result.modified_payload.result["isError"] is False
         assert result.metadata == {"secrets_redacted": True, "count": 1}
+
+    async def test_tool_post_invoke_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
+        payload = ToolPostInvokePayload(
+            name="writer",
+            result={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE",
+                    }
+                ],
+                "isError": False,
+            },
+        )
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.tool_post_invoke(plugin_input, make_context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"result"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert (
+            payload.result["content"][0]["text"]
+            == "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        )
+        assert filtered.result["content"][0]["text"] == "AWS_ACCESS_KEY_ID=[REDACTED]"
 
     async def test_tool_post_invoke_preserves_tuple_shape_when_redacted(self, plugin):
         payload = ToolPostInvokePayload(
@@ -290,6 +324,34 @@ class TestPluginHookResults:
         assert result.modified_payload is not None
         assert result.modified_payload.content.text == "SLACK_TOKEN=[REDACTED]"
         assert result.metadata == {"secrets_redacted": True, "count": 1}
+
+    async def test_resource_post_fetch_redaction_survives_cpex_policy(self, plugin):
+        payload = ResourcePostFetchPayload(
+            uri="file:///tmp/secret.txt",
+            content=ResourceContent(
+                type="resource",
+                id="res-1",
+                uri="file:///tmp/secret.txt",
+                text="SLACK_TOKEN=xoxr-fake-000000000-fake000000000-fakefakefakefake",
+            ),
+        )
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.resource_post_fetch(plugin_input, make_context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"content"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert (
+            payload.content.text
+            == "SLACK_TOKEN=xoxr-fake-000000000-fake000000000-fakefakefakefake"
+        )
+        assert filtered.content.text == "SLACK_TOKEN=[REDACTED]"
 
     async def test_resource_post_fetch_leaves_clean_payload_unmodified(self, plugin):
         payload = ResourcePostFetchPayload(

--- a/plugins/tests/secrets_detection/test_plugin_hooks.py
+++ b/plugins/tests/secrets_detection/test_plugin_hooks.py
@@ -1,5 +1,8 @@
 import pytest
 
+from cpex.framework.hooks.policies import HookPayloadPolicy, apply_policy
+from cpex.framework.memory import wrap_payload_for_isolation
+
 from secrets_detection.helpers import *  # noqa: F403,F405
 
 
@@ -22,6 +25,26 @@ class TestPluginHooks:
         assert result.modified_payload is not None
         assert result.modified_payload.args["input"] == "AWS_ACCESS_KEY_ID=[REDACTED]"
         assert result.metadata == {"secrets_redacted": True, "count": 1}
+
+    async def test_prompt_pre_fetch_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
+        payload = PromptPrehookPayload(
+            prompt_id="prompt-1",
+            args={"input": "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"},
+        )
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.prompt_pre_fetch(plugin_input, make_context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"args"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert payload.args["input"] == "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        assert filtered.args["input"] == "AWS_ACCESS_KEY_ID=[REDACTED]"
 
     async def test_prompt_pre_fetch_leaves_clean_payload_unmodified(self, plugin):
         payload = PromptPrehookPayload(
@@ -68,6 +91,26 @@ class TestPluginHooks:
         )
         assert payload.args["message"] == "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
         assert result.metadata == {"secrets_redacted": True, "count": 1}
+
+    async def test_tool_pre_invoke_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
+        payload = ToolPreInvokePayload(
+            name="echo",
+            args={"message": "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"},
+        )
+        plugin_input = wrap_payload_for_isolation(payload)
+
+        result = await plugin.tool_pre_invoke(plugin_input, make_context())
+
+        assert result.modified_payload is not None
+        filtered = apply_policy(
+            plugin_input,
+            result.modified_payload,
+            HookPayloadPolicy(writable_fields=frozenset({"args"})),
+            apply_to=payload,
+        )
+        assert filtered is not None
+        assert payload.args["message"] == "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        assert filtered.args["message"] == "AWS_ACCESS_KEY_ID=[REDACTED]"
 
     async def test_tool_pre_invoke_detects_copy_on_write_dict_arguments(self):
         class CopyOnWriteDict(dict):

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2314,6 +2314,20 @@ class PluginCatalogTests(unittest.TestCase):
                 capture_output=True,
                 check=True,
             )
+            subprocess.run(
+                ["git", "config", "gc.auto", "0"],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "maintenance.auto", "false"],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
             shutil.copytree(REPO_ROOT / "plugins", root / "plugins")
             shutil.copytree(REPO_ROOT / "crates", root / "crates")
             (root / "Cargo.toml").write_text((REPO_ROOT / "Cargo.toml").read_text())


### PR DESCRIPTION
Closes 
## Summary

- Fix encoded exfil scanning under CPEX copy-on-write payload isolation by reading mappings through the Python mapping protocol.
- Add policy/isolation regression coverage for mutation-capable plugins that did not already have this issue-specific coverage.
- Bump encoded exfil from 0.3.2 to 0.3.3 and refresh Cargo.lock / secrets baseline.

## Plugin Audit

| Plugin | Mutation-capable for this issue? | Result |
| --- | --- | --- |
| `pii_filter` | Yes | Already covered by PR #89; no extra change in PR #107. |
| `encoded_exfil_detection` | Yes | Fixed mapping scan under CPEX isolation; added policy regressions for `prompt_pre_fetch`, `tool_post_invoke`, `resource_post_fetch`. No `tool_pre_invoke` regression applies because this plugin does not implement or advertise that hook. |
| `secrets_detection` | Yes | Existing implementation already preserved policy-visible mutations; added policy regressions for `prompt_pre_fetch`, `tool_pre_invoke`, `tool_post_invoke`, `resource_post_fetch`. Test-only coverage change, so no plugin version bump. |
| `rate_limiter` | No | Does not return `modified_payload`; no regression needed for this issue. |
| `retry_with_backoff` | No | Does not return `modified_payload`; no regression needed for this issue. |
| `url_reputation` | No | Does not return `modified_payload`; no regression needed for this issue. |

## Root Cause

Encoded exfil directly cast nested containers to `PyDict`. CPEX policy isolation can wrap writable payload fields in copy-on-write mapping objects whose visible values are exposed through the mapping protocol, so direct `PyDict` iteration could miss nested values and produce no policy-visible `modified_payload`.

## Validation

- `CPEX_TEST_PLUGIN_HOOKS=1 uv run pytest ../../../tests/encoded_exfil_detection/test_integration.py -q --asyncio-mode=auto`
- `CPEX_TEST_PLUGIN_HOOKS=1 uv run pytest ../../../tests/secrets_detection -q --asyncio-mode=auto`
- `cargo nextest run -p encoded_exfil_detection`
- `cargo clippy -p encoded_exfil_detection -- -D warnings`
- `cargo fmt --check -p encoded_exfil_detection`
