### PR TITLE
Fix padded base64 secret detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets_detection"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/plugins/rust/python-package/secrets_detection/Cargo.toml
+++ b/plugins/rust/python-package/secrets_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secrets_detection"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect likely credentials and secrets in prompt input, tool output, and resource content"
 author: "ContextForge Contributors"
-version: "0.3.3"
+version: "0.3.4"
 kind: "cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
@@ -60,13 +60,18 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     );
     patterns.insert(
         "base64_24",
+        // Minimum valid padded base64 secrets are 24 total chars: 22 data
+        // chars plus `==`, or 23 data chars plus `=`.
         Regex::new(
-            r"(?:^|[^A-Za-z0-9+/])((?:[A-Za-z0-9+/]{24,}={0,2}|[A-Za-z0-9+/]{22}==|[A-Za-z0-9+/]{23}=))(?:$|[^A-Za-z0-9+/=])",
+            r"(?:^|[^A-Za-z0-9+/])((?:[A-Za-z0-9+/]{24,}={0,2}|[A-Za-z0-9+/]{22}==|[A-Za-z0-9+/]{23}=))",
         )
-            .expect("valid base64_24 regex"),
+        .expect("valid base64_24 regex"),
     );
     patterns
 });
+
+pub static CAPTURE_PATTERNS: LazyLock<HashSet<&'static str>> =
+    LazyLock::new(|| HashSet::from(["base64_24"]));
 
 #[cfg(test)]
 mod tests {

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -60,7 +60,10 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     );
     patterns.insert(
         "base64_24",
-        Regex::new(r"\b[A-Za-z0-9+/]{24,}={0,2}\b").expect("valid base64_24 regex"),
+        Regex::new(
+            r"(?:^|[^A-Za-z0-9+/])((?:[A-Za-z0-9+/]{24,}={0,2}|[A-Za-z0-9+/]{22}==|[A-Za-z0-9+/]{23}=))(?:$|[^A-Za-z0-9+/=])",
+        )
+            .expect("valid base64_24 regex"),
     );
     patterns
 });

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -325,11 +325,60 @@ mod tests {
             ..Default::default()
         };
 
-        let sample = ["mZ8qL2vYwT1p", "Nc4Rb6HxUg", "=="].concat();
+        let sample = "mZ8qL2vYwT1pNc4Rb6HxUg=="; // pragma: allowlist secret
         let (findings, redacted) = detect_and_redact(&format!("token={sample}"), &config);
 
         assert_eq!(findings.len(), 1, "{findings:?}");
         assert_eq!(findings[0].pii_type, "base64_24");
         assert_eq!(redacted, "token=[REDACTED]");
+    }
+
+    #[test]
+    fn detects_each_adjacent_padded_base64_secret() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            redact: true,
+            redaction_text: "[REDACTED]".to_string(),
+            ..Default::default()
+        };
+
+        let (findings, redacted) = detect_and_redact(
+            "tokens=ABCDEFGHIJKLMNOPQRSTUV==,ABCDEFGHIJKLMNOPQRSTUVW=", // pragma: allowlist secret
+            &config,
+        );
+
+        assert_eq!(findings.len(), 2, "{findings:?}");
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.pii_type == "base64_24")
+        );
+        assert_eq!(redacted, "tokens=[REDACTED],[REDACTED]");
+    }
+
+    #[test]
+    fn detects_single_padding_base64_secret() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            ..Default::default()
+        };
+
+        let (findings, _) = detect_and_redact("token=ABCDEFGHIJKLMNOPQRSTUVW=", &config); // pragma: allowlist secret
+
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].pii_type, "base64_24");
+    }
+
+    #[test]
+    fn detects_padded_base64_secret_with_plus_and_slash() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            ..Default::default()
+        };
+
+        let (findings, _) = detect_and_redact("token=ABCD+FGH/IJKLMNOPQRSTU==", &config); // pragma: allowlist secret
+
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].pii_type, "base64_24");
     }
 }

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -315,4 +315,21 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn redacts_padded_base64_secret_without_leaving_padding() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            redact: true,
+            redaction_text: "[REDACTED]".to_string(),
+            ..Default::default()
+        };
+
+        let sample = ["mZ8qL2vYwT1p", "Nc4Rb6HxUg", "=="].concat();
+        let (findings, redacted) = detect_and_redact(&format!("token={sample}"), &config);
+
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].pii_type, "base64_24");
+        assert_eq!(redacted, "token=[REDACTED]");
+    }
 }

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -381,4 +381,16 @@ mod tests {
         assert_eq!(findings.len(), 1, "{findings:?}");
         assert_eq!(findings[0].pii_type, "base64_24");
     }
+
+    #[test]
+    fn ignores_padded_base64_prefix_followed_by_base64_char() {
+        let config = SecretsDetectionConfig {
+            enabled: std::collections::HashMap::from([("base64_24".to_string(), true)]),
+            ..Default::default()
+        };
+
+        let (findings, _) = detect_and_redact("token=ABCDEFGHIJKLMNOPQRSTUV==A", &config); // pragma: allowlist secret
+
+        assert!(findings.is_empty(), "{findings:?}");
+    }
 }

--- a/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
@@ -25,13 +25,27 @@ pub fn detect_and_redact(text: &str, config: &SecretsDetectionConfig) -> (Vec<Fi
             continue;
         }
 
-        for matched in pattern.find_iter(text) {
-            candidates.push(MatchCandidate {
-                name,
-                start: matched.start(),
-                end: matched.end(),
-                text: matched.as_str(),
-            });
+        if *name == "base64_24" {
+            for captures in pattern.captures_iter(text) {
+                let Some(matched) = captures.get(1) else {
+                    continue;
+                };
+                candidates.push(MatchCandidate {
+                    name,
+                    start: matched.start(),
+                    end: matched.end(),
+                    text: matched.as_str(),
+                });
+            }
+        } else {
+            for matched in pattern.find_iter(text) {
+                candidates.push(MatchCandidate {
+                    name,
+                    start: matched.start(),
+                    end: matched.end(),
+                    text: matched.as_str(),
+                });
+            }
         }
     }
 

--- a/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::SecretsDetectionConfig;
-use crate::patterns::PATTERNS;
+use crate::patterns::{CAPTURE_PATTERNS, PATTERNS};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Finding {
@@ -25,11 +25,16 @@ pub fn detect_and_redact(text: &str, config: &SecretsDetectionConfig) -> (Vec<Fi
             continue;
         }
 
-        if *name == "base64_24" {
+        if CAPTURE_PATTERNS.contains(name) {
+            // Capturing patterns exclude boundary chars from findings. Rust
+            // regex has no lookbehind, so group 1 is the actual secret span.
             for captures in pattern.captures_iter(text) {
                 let Some(matched) = captures.get(1) else {
                     continue;
                 };
+                if is_base64_boundary_char(text[matched.end()..].chars().next()) {
+                    continue;
+                }
                 candidates.push(MatchCandidate {
                     name,
                     start: matched.start(),
@@ -124,4 +129,8 @@ fn pattern_specificity(name: &str) -> usize {
         "base64_24" => 3,
         _ => 0,
     }
+}
+
+fn is_base64_boundary_char(ch: Option<char>) -> bool {
+    ch.is_some_and(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '/' | '='))
 }


### PR DESCRIPTION
## Summary
- Fix padded base64 secret detection so encoded secrets with trailing padding are matched correctly
- Avoid consuming trailing separators so adjacent padded base64 secrets are detected independently
- Add scanner coverage for double-equals padding, single-equals padding, adjacent padded values, plus/slash payload characters, and base64-char boundary rejection
- Bump the secrets-detection plugin version metadata

## Tracker
- https://github.ibm.com/WatsonOrchestrate/wo-tracker/issues/70713

## Testing
- make test-unit
- make fmt-check clippy test-integration
- cargo mutants -p secrets_detection --in-diff cargo-mutants.diff