### PR TITLE
fix(rate-limiter): enable rustls default features so TLS 1.2 Redis connects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rate_limiter"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +147,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -209,6 +233,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "combine"
@@ -378,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,13 +581,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -787,6 +844,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1359,6 +1426,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1582,6 +1655,8 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1617,6 +1692,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -31,28 +31,8 @@ mutants = "0.0.4"
 parking_lot = "0.12.5"
 thiserror = { workspace = true }
 redis = { version = "1.2.1", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-insecure", "tokio-rustls-comp"] }
-# Direct rustls dep with the `ring` crypto provider feature. redis 1.2
-# pulls rustls in transitively but via `default-features = false`, so no
-# crypto provider is enabled by default — rustls 0.23 then panics at
-# first TLS use ("Call CryptoProvider::install_default()..."). We add
-# `ring` here and install it as the default provider once at plugin init.
-#
-# Note on CA roots: by NOT enabling `tls-rustls-webpki-roots`, the redis
-# crate falls back to `rustls-native-certs` (Apache-2.0 / MIT / ISC) which
-# reads CA certificates from the host OS trust store at runtime. This
-# avoids a transitive dep on `webpki-roots` (CDLA-Permissive-2.0). The
-# trade-off: the host container must have a CA bundle installed — true
-# for the UBI Minimal image mcp-context-forge ships on, and for any
-# distribution that keeps `ca-certificates` in its base.
-#
-# `tls12` is REQUIRED. With `default-features = false`, rustls 0.23 compiles
-# WITHOUT TLS 1.2 support (1.3-only), and the redis crate's `tls-rustls`
-# feature does not enable it. Managed Redis that only offers TLS 1.2 (e.g. AWS
-# ElastiCache) then has no protocol version in common with the client, and the
-# handshake dies with "unexpected end of file" — surfacing as BACKEND_UNAVAILABLE
-# even though redis-py (OpenSSL) connects to the same endpoint. Enabling `tls12`
-# restores TLS 1.2 while keeping 1.3.
-rustls = { version = "0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
+# Enable default features (includes tls12 for TLS 1.2 support) plus the ring provider.
+rustls = { version = "0.23.40", features = ["ring"] }
 rustls-pki-types = "1.14"
 tokio = { workspace = true }
 

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rate_limiter"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -44,7 +44,15 @@ redis = { version = "1.2.1", features = ["aio", "tokio-comp", "tls-rustls", "tls
 # trade-off: the host container must have a CA bundle installed — true
 # for the UBI Minimal image mcp-context-forge ships on, and for any
 # distribution that keeps `ca-certificates` in its base.
-rustls = { version = "0.23.40", default-features = false, features = ["ring", "std"] }
+#
+# `tls12` is REQUIRED. With `default-features = false`, rustls 0.23 compiles
+# WITHOUT TLS 1.2 support (1.3-only), and the redis crate's `tls-rustls`
+# feature does not enable it. Managed Redis that only offers TLS 1.2 (e.g. AWS
+# ElastiCache) then has no protocol version in common with the client, and the
+# handshake dies with "unexpected end of file" — surfacing as BACKEND_UNAVAILABLE
+# even though redis-py (OpenSSL) connects to the same endpoint. Enabling `tls12`
+# restores TLS 1.2 while keeping 1.3.
+rustls = { version = "0.23.40", default-features = false, features = ["ring", "std", "tls12"] }
 rustls-pki-types = "1.14"
 tokio = { workspace = true }
 

--- a/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
+++ b/plugins/rust/python-package/rate_limiter/cpex_rate_limiter/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Rate limiting by user/tenant/tool — memory (single-process) or Redis (shared across instances)"
 author: "ContextForge Contributors"
-version: "0.1.3"
+version: "0.1.4"
 kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/rate_limiter/src/redis_backend.rs
+++ b/plugins/rust/python-package/rate_limiter/src/redis_backend.rs
@@ -953,6 +953,19 @@ mod tests {
     // RedisTlsConfig tests
     // ---------------------------------------------------------------------------
 
+    /// Regression guard: the rustls `tls12` feature must stay enabled.
+    /// Without it rustls compiles TLS 1.3-only and cannot connect to a TLS-1.2-only
+    /// managed Redis (e.g. AWS ElastiCache), failing with BACKEND_UNAVAILABLE.
+    /// `rustls::version::TLS12` only exists when the feature is on, so removing it
+    /// breaks this build.
+    #[test]
+    fn rustls_tls12_feature_is_enabled() {
+        assert_eq!(
+            rustls::version::TLS12.version,
+            rustls::ProtocolVersion::TLSv1_2
+        );
+    }
+
     #[test]
     fn tls_no_knobs_returns_none() {
         // Default config (no TLS knobs) must take the fast path and return None


### PR DESCRIPTION
## Summary

cpex-rate-limiter pinned rustls with `default-features = false` and only `["ring", "std"]`,
so rustls compiled without TLS 1.2 (1.3-only); the redis crate's `tls-rustls` feature does
not enable `tls12` either. A Redis endpoint that offers only TLS 1.2 (e.g. AWS ElastiCache)
then shares no protocol version with the client: the handshake fails ("unexpected end of
file") and the plugin returns BACKEND_UNAVAILABLE, even though redis-py (OpenSSL) connects
to the same endpoint.

## Fix

Enable rustls's default features (which include `tls12`) and keep the `ring` provider,
matching the pinning used by contextforge-gateway-rs. Restores TLS 1.2 while keeping 1.3.
Bumps the package to 0.1.4 and adds a regression test that fails to build if `tls12` is
dropped.

## Validation

Confirmed against a live AWS ElastiCache instance: the stock build returns
BACKEND_UNAVAILABLE; this build connects and writes rate-limit keys. Release-validation
wheels build on all targets (linux x86_64/aarch64/ppc64le/s390x, windows, macos).
