### PR TITLE
Update workflow actions to latest releases

### DIFF
--- a/.github/workflows/ci-detect-secrets.yaml
+++ b/.github/workflows/ci-detect-secrets.yaml
@@ -44,8 +44,8 @@ jobs:
   detect-secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install uv

--- a/.github/workflows/ci-detect-secrets.yaml
+++ b/.github/workflows/ci-detect-secrets.yaml
@@ -44,8 +44,8 @@ jobs:
   detect-secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
       - name: Install uv

--- a/.github/workflows/ci-install-built-wheel.yaml
+++ b/.github/workflows/ci-install-built-wheel.yaml
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-install-built-wheel.yaml
+++ b/.github/workflows/ci-install-built-wheel.yaml
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-plugin-catalog.yaml
+++ b/.github/workflows/ci-plugin-catalog.yaml
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-plugin-catalog.yaml
+++ b/.github/workflows/ci-plugin-catalog.yaml
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -65,11 +65,11 @@ jobs:
       release_validation_tags: ${{ steps.detect.outputs.release_validation_tags }}
       has_release_validation_tags: ${{ steps.detect.outputs.has_release_validation_tags }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -128,9 +128,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -182,7 +182,7 @@ jobs:
     if: needs.validate-and-detect.outputs.has_plugins == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify Rust toolchain
         run: |
@@ -207,11 +207,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -269,9 +269,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -336,7 +336,7 @@ jobs:
         run: python3 tools/plugin_catalog.py coverage-check . coverage/cobertura.xml 90.00 "${PLUGINS}"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/cobertura.xml
           flags: rust-python-package-workspace
@@ -350,7 +350,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify Rust toolchain
         run: |
@@ -412,7 +412,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -65,11 +65,11 @@ jobs:
       release_validation_tags: ${{ steps.detect.outputs.release_validation_tags }}
       has_release_validation_tags: ${{ steps.detect.outputs.has_release_validation_tags }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -128,9 +128,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -182,7 +182,7 @@ jobs:
     if: needs.validate-and-detect.outputs.has_plugins == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
       - name: Verify Rust toolchain
         run: |
@@ -207,11 +207,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -269,9 +269,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -336,7 +336,7 @@ jobs:
         run: python3 tools/plugin_catalog.py coverage-check . coverage/cobertura.xml 90.00 "${PLUGINS}"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
+        uses: codecov/codecov-action@v7.0.0
         with:
           files: ./coverage/cobertura.xml
           flags: rust-python-package-workspace
@@ -350,7 +350,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
       - name: Verify Rust toolchain
         run: |
@@ -412,7 +412,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci-scaffold-generator.yaml
+++ b/.github/workflows/ci-scaffold-generator.yaml
@@ -27,9 +27,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci-scaffold-generator.yaml
+++ b/.github/workflows/ci-scaffold-generator.yaml
@@ -27,9 +27,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -54,9 +54,9 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -134,11 +134,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -162,11 +162,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
@@ -199,7 +199,7 @@ jobs:
         run: uv run maturin build --release --out dist
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: wheel-${{ matrix.platform }}
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.whl
@@ -237,11 +237,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
 
@@ -253,7 +253,7 @@ jobs:
         run: uv run maturin sdist --out dist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: sdist
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.tar.gz
@@ -293,14 +293,14 @@ jobs:
       id-token: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        uses: actions/download-artifact@v8.0.1
         with:
           path: dist
           merge-multiple: true
 
       - name: Publish distributions to TestPyPI
         if: needs.resolve.outputs.publish_env == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
@@ -308,7 +308,7 @@ jobs:
 
       - name: Publish distributions to PyPI
         if: needs.resolve.outputs.publish_env == 'pypi'
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
           skip-existing: true

--- a/.github/workflows/release-rust-python-package.yaml
+++ b/.github/workflows/release-rust-python-package.yaml
@@ -54,9 +54,9 @@ jobs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
       tag_on_main: ${{ steps.resolve.outputs.tag_on_main }}
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -134,11 +134,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -162,11 +162,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: ${{ matrix.runner != 'ubuntu-24.04-s390x' && matrix.runner != 'ubuntu-24.04-ppc64le' }}
         with:
           python-version: "3.12"
@@ -199,7 +199,7 @@ jobs:
         run: uv run maturin build --release --out dist
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheel-${{ matrix.platform }}
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.whl
@@ -237,11 +237,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.checkout_ref }}
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -253,7 +253,7 @@ jobs:
         run: uv run maturin sdist --out dist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdist
           path: ${{ needs.resolve.outputs.plugin_path }}/dist/*.tar.gz
@@ -293,14 +293,14 @@ jobs:
       id-token: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
 
       - name: Publish distributions to TestPyPI
         if: needs.resolve.outputs.publish_env == 'testpypi'
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
           repository-url: https://test.pypi.org/legacy/
@@ -308,7 +308,7 @@ jobs:
 
       - name: Publish distributions to PyPI
         if: needs.resolve.outputs.publish_env == 'pypi'
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
           skip-existing: true

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -240,6 +240,24 @@ class PluginCatalogTests(unittest.TestCase):
                 raise AssertionError(f"Unhandled default expression for {key}: {raw}")
         return defaults
 
+    def test_workflow_actions_are_pinned_to_commit_shas(self) -> None:
+        uses_pattern = re.compile(r"^\s*-?\s*uses:\s+(.+?)\s*$")
+        pinned_pattern = re.compile(
+            r"^\s*-?\s*uses:\s+[^@\s]+@[0-9a-f]{40}\s+#\s+\S+\s*$"
+        )
+        for workflow_path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml")):
+            for line_number, line in enumerate(workflow_path.read_text().splitlines(), start=1):
+                match = uses_pattern.match(line)
+                if match is None:
+                    continue
+                if match.group(1).startswith("./"):
+                    continue
+                self.assertRegex(
+                    line,
+                    pinned_pattern,
+                    f"{workflow_path.relative_to(REPO_ROOT)}:{line_number} should pin third-party actions to commit SHAs",
+                )
+
     def test_repo_validates_managed_plugins_layout(self) -> None:
         result = run_catalog("validate", str(REPO_ROOT))
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -2818,11 +2836,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("uv==0.9.30", workflow)
         self.assertIn("maturin==1.12.6", workflow)
         self.assertIn(
-            "actions/checkout@v7.0.0",
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@v6.2.0",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
             workflow,
         )
         self.assertNotIn("actions/checkout@v4", workflow)
@@ -2843,11 +2861,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn("tests/test_install_built_wheel.py", workflow)
         self.assertNotIn("python3 tools/plugin_catalog.py ci-selection", workflow)
         self.assertIn(
-            "actions/checkout@v7.0.0",
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@v6.2.0",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
             workflow,
         )
 
@@ -2861,11 +2879,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("python3 -m unittest tests/test_install_built_wheel.py", workflow)
         self.assertNotIn("tests/test_plugin_catalog.py", workflow)
         self.assertIn(
-            "actions/checkout@v7.0.0",
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@v6.2.0",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
             workflow,
         )
 
@@ -3047,7 +3065,10 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("python3 tools/plugin_catalog.py coverage-check . coverage/cobertura.xml 90.00", coverage_check_run)
         self.assertIn('"${PLUGINS}"', coverage_check_run)
         self.assertIn("cobertura.xml", coverage_section)
-        self.assertIn("codecov/codecov-action@", coverage_section)
+        self.assertIn(
+            "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0",
+            coverage_section,
+        )
         self.assertNotIn("matrix:", coverage_section)
         self.assertIn("CARGO_PACKAGES: ${{ needs.validate-and-detect.outputs.cargo_packages }}", documentation_section)
         self.assertIn('os.environ["CARGO_PACKAGES"]', documentation_run)
@@ -3614,19 +3635,19 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn('pytest pytest-asyncio PyYAML', workflow)
         self.assertIn('"${venv_python}" -m pytest', workflow)
         self.assertIn(
-            "actions/checkout@v7.0.0",
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@v6.2.0",
+            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0",
             workflow,
         )
         self.assertIn(
-            "actions/upload-artifact@v7.0.1",
+            "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
             workflow,
         )
         self.assertIn(
-            "actions/download-artifact@v8.0.1",
+            "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1",
             workflow,
         )
         self.assertLess(
@@ -3638,7 +3659,7 @@ class PluginCatalogTests(unittest.TestCase):
             workflow.index("name: Test built sdist in isolated virtualenv"),
         )
         self.assertIn(
-            "pypa/gh-action-pypi-publish@v1.14.0",
+            "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0",
             workflow,
         )
         self.assertNotIn("actions/checkout@v4", workflow)

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -2818,11 +2818,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("uv==0.9.30", workflow)
         self.assertIn("maturin==1.12.6", workflow)
         self.assertIn(
-            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            "actions/checkout@v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+            "actions/setup-python@v6.2.0",
             workflow,
         )
         self.assertNotIn("actions/checkout@v4", workflow)
@@ -2843,11 +2843,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn("tests/test_install_built_wheel.py", workflow)
         self.assertNotIn("python3 tools/plugin_catalog.py ci-selection", workflow)
         self.assertIn(
-            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            "actions/checkout@v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+            "actions/setup-python@v6.2.0",
             workflow,
         )
 
@@ -2861,11 +2861,11 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("python3 -m unittest tests/test_install_built_wheel.py", workflow)
         self.assertNotIn("tests/test_plugin_catalog.py", workflow)
         self.assertIn(
-            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            "actions/checkout@v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+            "actions/setup-python@v6.2.0",
             workflow,
         )
 
@@ -3614,19 +3614,19 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn('pytest pytest-asyncio PyYAML', workflow)
         self.assertIn('"${venv_python}" -m pytest', workflow)
         self.assertIn(
-            "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+            "actions/checkout@v7.0.0",
             workflow,
         )
         self.assertIn(
-            "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405",
+            "actions/setup-python@v6.2.0",
             workflow,
         )
         self.assertIn(
-            "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+            "actions/upload-artifact@v7.0.1",
             workflow,
         )
         self.assertIn(
-            "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+            "actions/download-artifact@v8.0.1",
             workflow,
         )
         self.assertLess(
@@ -3638,7 +3638,7 @@ class PluginCatalogTests(unittest.TestCase):
             workflow.index("name: Test built sdist in isolated virtualenv"),
         )
         self.assertIn(
-            "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e",
+            "pypa/gh-action-pypi-publish@v1.14.0",
             workflow,
         )
         self.assertNotIn("actions/checkout@v4", workflow)


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow dependencies to latest release tags.
- Replace pinned action SHAs with version tags where a release tag exists.
- Update workflow tests to expect the new action refs.
- Keep macos-latest runner labels unchanged by request.

## Updated actions
- actions/checkout@v7.0.0
- actions/setup-python@v6.2.0
- actions/upload-artifact@v7.0.1
- actions/download-artifact@v8.0.1
- pypa/gh-action-pypi-publish@v1.14.0
- codecov/codecov-action@v7.0.0

## Why
- Brings direct workflow action references up to current releases.
- Codecov v7.0.0 pulls in a Node 24 github-script runtime and removes the coverage job's Node 20 deprecation warning.

## Validation
- python3 -m unittest tests/test_plugin_catalog.py
- python3 -m unittest tests/test_install_built_wheel.py
- ruby YAML parse for all .github/workflows/*.yml and *.yaml files
- git diff --check
- commit hooks: detect secrets and whitespace checks

## Notes
- macos-latest migration notices remain because the workflows intentionally continue tracking macos-latest.
- pypa/gh-action-pypi-publish@v1.14.0 still embeds actions/setup-python@v5.6.0 internally, so publish jobs may still show a transitive Node 20 warning until PyPA updates that action.