### PR TITLE
Add field filters to secrets detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets_detection"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/plugins/rust/python-package/secrets_detection/Cargo.toml
+++ b/plugins/rust/python-package/secrets_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secrets_detection"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/secrets_detection/README.md
+++ b/plugins/rust/python-package/secrets_detection/README.md
@@ -9,6 +9,7 @@ Rust-backed secrets detection and redaction for ContextForge and MCP Gateway.
 - Optional broad detectors for generic API key assignments, JWT-like strings, long hex strings, and base64-like secrets
 - Blocking, redaction, or metadata-only reporting modes
 - Recursive scanning for nested dicts, lists, tuples, Pydantic-style objects, `__dict__`, and `__slots__`
+- Optional dotted field allowlist and denylist controls for structured payload scanning
 - Sanitized outward metadata that reports finding types and counts, not original secret values
 
 ## Build
@@ -77,6 +78,8 @@ config:
   redaction_text: "***REDACTED***"
   block_on_detection: true
   min_findings_to_block: 1
+  field_allowlist: []
+  field_denylist: []
 ```
 
 | Field | Type | Default | Description |
@@ -86,6 +89,44 @@ config:
 | `redaction_text` | string | `"***REDACTED***"` | Replacement text used when `redact=true` |
 | `block_on_detection` | bool | `true` | Return a violation when enough findings are present |
 | `min_findings_to_block` | integer | `1` | Minimum finding count required before blocking |
+| `field_allowlist` | list[string] | `[]` | Dotted field paths eligible for scanning; empty means all structured fields are eligible |
+| `field_denylist` | list[string] | `[]` | Dotted field paths excluded from scanning; denylist entries take precedence over allowlist entries |
+
+### Field Filtering
+
+`field_allowlist` and `field_denylist` apply to structured scan targets:
+
+- `prompt_pre_fetch`: paths are relative to `payload.args`
+- `tool_pre_invoke`: paths are relative to `payload.args`
+- `tool_post_invoke`: paths are relative to `payload.result`
+
+For example, `accounts.credentials.token` matches `payload.args.accounts.credentials.token` in pre-hooks and `payload.result.accounts.credentials.token` in `tool_post_invoke`.
+
+Rules:
+
+- An empty `field_allowlist` scans all structured fields.
+- A non-empty `field_allowlist` scans only the listed paths and their descendants.
+- A `field_denylist` entry excludes that path and all descendants.
+- When both lists match, `field_denylist` wins.
+- Parent containers are still traversed to reach nested allowlisted paths.
+- Matching is segment-aware: `layer1` does not match `layer10`.
+- Lists and tuples are transparent to field matching; numeric indices are not used.
+- Mapping keys themselves are not scanned.
+- Direct scalar scan targets, including `payload.content.text` in `resource_post_fetch`, retain current behavior and are not filtered by field paths.
+
+Valid field paths use non-empty dot-separated segments. Empty paths, whitespace-only paths, leading or trailing dots, and empty segments such as `layer1..token` are rejected during plugin initialization.
+
+Example:
+
+```yaml
+config:
+  field_allowlist:
+    - "layer1"
+    - "accounts.credentials"
+  field_denylist:
+    - "layer1.layer2.layer3"
+    - "accounts.credentials.test_token"
+```
 
 ## Behavior Notes
 
@@ -120,6 +161,12 @@ result.metadata["secrets_detection"] = {
 Blocking responses use the `SECRETS_DETECTED` violation code.
 
 ## Migration Note
+
+Version `0.3.8` adds optional field filtering:
+
+- `field_allowlist` and `field_denylist` default to empty lists, so existing configurations keep scanning the same fields as before.
+- When configured, field filters affect detection counts, metadata, redaction, `min_findings_to_block`, and blocking decisions.
+- `field_denylist` entries take precedence over `field_allowlist` entries.
 
 Version `0.3.7` is a **breaking change** for any existing consumer reading detection metadata:
 

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect likely credentials and secrets in prompt input, tool output, and resource content"
 author: "ContextForge Contributors"
-version: "0.3.8"
+version: "0.3.9"
 kind: "cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -24,3 +24,5 @@ default_configs:
   redaction_text: "***REDACTED***"
   block_on_detection: true
   min_findings_to_block: 1
+  field_allowlist: []
+  field_denylist: []

--- a/plugins/rust/python-package/secrets_detection/src/config.rs
+++ b/plugins/rust/python-package/secrets_detection/src/config.rs
@@ -22,11 +22,87 @@ pub struct SecretsDetectionConfig {
     pub redaction_text: String,
     pub block_on_detection: bool,
     pub min_findings_to_block: usize,
+    pub field_allowlist: Vec<FieldPath>,
+    pub field_denylist: Vec<FieldPath>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldPath {
+    segments: Vec<String>,
+}
+
+impl FieldPath {
+    fn parse(path: String, field_name: &str) -> PyResult<Self> {
+        if path.trim().is_empty() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "{field_name} entries must not be empty or whitespace-only"
+            )));
+        }
+        if path.starts_with('.') || path.ends_with('.') {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "{field_name} path {path:?} must not start or end with '.'"
+            )));
+        }
+
+        let segments: Vec<String> = path.split('.').map(ToString::to_string).collect();
+        if segments.iter().any(|segment| segment.trim().is_empty()) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "{field_name} path {path:?} must not contain empty or whitespace-only segments"
+            )));
+        }
+
+        Ok(Self { segments })
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    fn matches_path_or_descendant(&self, path: &[String]) -> bool {
+        path_starts_with(path, &self.segments)
+    }
+
+    fn can_be_reached_from(&self, path: &[String]) -> bool {
+        path_starts_with(&self.segments, path)
+    }
 }
 
 impl SecretsDetectionConfig {
     pub fn is_enabled(&self, name: &str) -> bool {
         self.enabled.get(name).copied().unwrap_or(false)
+    }
+
+    pub fn should_scan_field_path(&self, path: &[String], direct_scalar_root: bool) -> bool {
+        if direct_scalar_root && path.is_empty() {
+            return true;
+        }
+        if self.path_is_denied(path) {
+            return false;
+        }
+        self.field_allowlist.is_empty()
+            || self
+                .field_allowlist
+                .iter()
+                .any(|allow_path| allow_path.matches_path_or_descendant(path))
+    }
+
+    pub fn should_traverse_field_path(&self, path: &[String]) -> bool {
+        if path.is_empty() {
+            return true;
+        }
+        if self.path_is_denied(path) {
+            return false;
+        }
+        self.field_allowlist.is_empty()
+            || self.field_allowlist.iter().any(|allow_path| {
+                allow_path.matches_path_or_descendant(path) || allow_path.can_be_reached_from(path)
+            })
+    }
+
+    fn path_is_denied(&self, path: &[String]) -> bool {
+        self.field_denylist
+            .iter()
+            .any(|deny_path| deny_path.matches_path_or_descendant(path))
     }
 
     pub fn from_py_any(config: &Bound<'_, PyAny>) -> PyResult<Self> {
@@ -65,6 +141,18 @@ impl SecretsDetectionConfig {
             .map(|value| value.extract::<usize>())
             .transpose()?
             .unwrap_or(1);
+        let field_allowlist = config
+            .getattr("field_allowlist")
+            .ok()
+            .map(|value| parse_field_paths(&value, "field_allowlist"))
+            .transpose()?
+            .unwrap_or_default();
+        let field_denylist = config
+            .getattr("field_denylist")
+            .ok()
+            .map(|value| parse_field_paths(&value, "field_denylist"))
+            .transpose()?
+            .unwrap_or_default();
 
         Ok(Self {
             enabled,
@@ -72,6 +160,8 @@ impl SecretsDetectionConfig {
             redaction_text,
             block_on_detection,
             min_findings_to_block,
+            field_allowlist,
+            field_denylist,
         })
     }
 
@@ -102,6 +192,16 @@ impl SecretsDetectionConfig {
             .map(|value| value.extract::<usize>())
             .transpose()?
             .unwrap_or(1);
+        let field_allowlist = dict
+            .get_item("field_allowlist")?
+            .map(|value| parse_field_paths(&value, "field_allowlist"))
+            .transpose()?
+            .unwrap_or_default();
+        let field_denylist = dict
+            .get_item("field_denylist")?
+            .map(|value| parse_field_paths(&value, "field_denylist"))
+            .transpose()?
+            .unwrap_or_default();
 
         Ok(Self {
             enabled,
@@ -109,6 +209,8 @@ impl SecretsDetectionConfig {
             redaction_text,
             block_on_detection,
             min_findings_to_block,
+            field_allowlist,
+            field_denylist,
         })
     }
 }
@@ -121,8 +223,31 @@ impl Default for SecretsDetectionConfig {
             redaction_text: "***REDACTED***".to_string(),
             block_on_detection: true,
             min_findings_to_block: 1,
+            field_allowlist: Vec::new(),
+            field_denylist: Vec::new(),
         }
     }
+}
+
+fn parse_field_paths(value: &Bound<'_, PyAny>, field_name: &str) -> PyResult<Vec<FieldPath>> {
+    value
+        .extract::<Vec<String>>()
+        .map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "{field_name} must be a list of dotted field path strings"
+            ))
+        })?
+        .into_iter()
+        .map(|path| FieldPath::parse(path, field_name))
+        .collect()
+}
+
+fn path_starts_with(path: &[String], prefix: &[String]) -> bool {
+    path.len() >= prefix.len()
+        && path
+            .iter()
+            .zip(prefix.iter())
+            .all(|(left, right)| left == right)
 }
 
 fn default_enabled_map() -> HashMap<String, bool> {
@@ -152,6 +277,8 @@ mod tests {
         assert!(!config.is_enabled("generic_api_key_assignment"));
         assert!(!config.is_enabled("jwt_like"));
         assert!(config.is_enabled("aws_access_key_id"));
+        assert!(config.field_allowlist.is_empty());
+        assert!(config.field_denylist.is_empty());
     }
 
     #[test]
@@ -167,6 +294,11 @@ mod tests {
             dict.set_item("redaction_text", "[SECRET]")?;
             dict.set_item("block_on_detection", false)?;
             dict.set_item("min_findings_to_block", 3)?;
+            dict.set_item("field_allowlist", ["layer1", "accounts.credentials"])?;
+            dict.set_item(
+                "field_denylist",
+                ["layer1.layer2.layer3", "accounts.credentials.test_token"],
+            )?;
 
             let config = SecretsDetectionConfig::from_py_dict(&dict)?;
 
@@ -177,6 +309,19 @@ mod tests {
             assert_eq!(config.redaction_text, "[SECRET]");
             assert!(!config.block_on_detection);
             assert_eq!(config.min_findings_to_block, 3);
+            assert_eq!(segments(&config.field_allowlist[0]), vec!["layer1"]);
+            assert_eq!(
+                segments(&config.field_allowlist[1]),
+                vec!["accounts", "credentials"]
+            );
+            assert_eq!(
+                segments(&config.field_denylist[0]),
+                vec!["layer1", "layer2", "layer3"]
+            );
+            assert_eq!(
+                segments(&config.field_denylist[1]),
+                vec!["accounts", "credentials", "test_token"]
+            );
             Ok(())
         })
         .unwrap();
@@ -194,6 +339,8 @@ class Config:
     redaction_text = "[MASKED]"
     block_on_detection = False
     min_findings_to_block = 2
+    field_allowlist = ["payload.token"]
+    field_denylist = ["payload.test_token"]
 "#,
             )
             .unwrap();
@@ -208,8 +355,182 @@ class Config:
             assert_eq!(config.redaction_text, "[MASKED]");
             assert!(!config.block_on_detection);
             assert_eq!(config.min_findings_to_block, 2);
+            assert_eq!(
+                segments(&config.field_allowlist[0]),
+                vec!["payload", "token"]
+            );
+            assert_eq!(
+                segments(&config.field_denylist[0]),
+                vec!["payload", "test_token"]
+            );
             Ok(())
         })
         .unwrap();
+    }
+
+    #[test]
+    fn from_py_dict_rejects_invalid_field_paths() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            for (field_name, path, expected) in [
+                (
+                    "field_allowlist",
+                    "",
+                    "must not be empty or whitespace-only",
+                ),
+                (
+                    "field_allowlist",
+                    "   ",
+                    "must not be empty or whitespace-only",
+                ),
+                ("field_denylist", ".token", "must not start or end with '.'"),
+                ("field_denylist", "token.", "must not start or end with '.'"),
+                (
+                    "field_allowlist",
+                    "layer1..layer3",
+                    "must not contain empty or whitespace-only segments",
+                ),
+                (
+                    "field_denylist",
+                    "layer1. .layer3",
+                    "must not contain empty or whitespace-only segments",
+                ),
+            ] {
+                let dict = PyDict::new(py);
+                dict.set_item(field_name, [path])?;
+
+                let err = SecretsDetectionConfig::from_py_dict(&dict)
+                    .expect_err("invalid field path should fail config parsing");
+
+                assert!(
+                    err.to_string().contains(expected),
+                    "{field_name}={path:?}: {err}"
+                );
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn from_py_dict_rejects_non_string_field_path_entries() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let dict = PyDict::new(py);
+            dict.set_item("field_allowlist", [1])?;
+
+            let err = SecretsDetectionConfig::from_py_dict(&dict)
+                .expect_err("non-string path should fail config parsing");
+
+            assert!(
+                err.to_string()
+                    .contains("field_allowlist must be a list of dotted field path strings"),
+                "{err}"
+            );
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn field_path_matcher_scans_and_traverses_everything_by_default() {
+        let config = SecretsDetectionConfig::default();
+
+        assert!(config.should_scan_field_path(&path(&[]), true));
+        assert!(config.should_scan_field_path(&path(&["layer1"]), false));
+        assert!(config.should_scan_field_path(&path(&["accounts", "credentials", "token"]), false));
+        assert!(config.should_traverse_field_path(&path(&[])));
+        assert!(config.should_traverse_field_path(&path(&["layer1"])));
+        assert!(config.should_traverse_field_path(&path(&["accounts", "credentials"])));
+    }
+
+    #[test]
+    fn field_path_matcher_allows_listed_paths_and_descendants() {
+        let config = config_with_field_paths(&["layer1"], &[]);
+
+        assert!(config.should_scan_field_path(&path(&[]), true));
+        assert!(!config.should_scan_field_path(&path(&[]), false));
+        assert!(config.should_scan_field_path(&path(&["layer1"]), false));
+        assert!(config.should_scan_field_path(&path(&["layer1", "public"]), false));
+        assert!(config.should_traverse_field_path(&path(&[])));
+        assert!(config.should_traverse_field_path(&path(&["layer1"])));
+        assert!(config.should_traverse_field_path(&path(&["layer1", "public"])));
+        assert!(!config.should_scan_field_path(&path(&["layer10"]), false));
+        assert!(!config.should_traverse_field_path(&path(&["layer10"])));
+    }
+
+    #[test]
+    fn field_path_matcher_traverses_unselected_parents_to_reach_nested_allowlist() {
+        let config = config_with_field_paths(&["accounts.credentials.token"], &[]);
+
+        assert!(config.should_traverse_field_path(&path(&[])));
+        assert!(config.should_traverse_field_path(&path(&["accounts"])));
+        assert!(config.should_traverse_field_path(&path(&["accounts", "credentials"])));
+        assert!(!config.should_scan_field_path(&path(&["accounts"]), false));
+        assert!(!config.should_scan_field_path(&path(&["accounts", "credentials"]), false));
+        assert!(config.should_scan_field_path(&path(&["accounts", "credentials", "token"]), false));
+        assert!(
+            config.should_scan_field_path(
+                &path(&["accounts", "credentials", "token", "value"]),
+                false
+            )
+        );
+        assert!(!config.should_traverse_field_path(&path(&["profile"])));
+    }
+
+    #[test]
+    fn field_path_matcher_denylist_takes_precedence() {
+        let config = config_with_field_paths(&["layer1"], &["layer1.layer2.layer3"]);
+
+        assert!(config.should_scan_field_path(&path(&["layer1", "public"]), false));
+        assert!(config.should_traverse_field_path(&path(&["layer1", "layer2"])));
+        assert!(config.should_scan_field_path(&path(&["layer1", "layer2", "safe"]), false));
+        assert!(!config.should_scan_field_path(&path(&["layer1", "layer2", "layer3"]), false));
+        assert!(!config.should_traverse_field_path(&path(&["layer1", "layer2", "layer3"])));
+        assert!(
+            !config.should_scan_field_path(&path(&["layer1", "layer2", "layer3", "token"]), false)
+        );
+        assert!(
+            !config.should_traverse_field_path(&path(&["layer1", "layer2", "layer3", "token"]))
+        );
+    }
+
+    #[test]
+    fn field_path_matcher_uses_segment_aware_matching() {
+        let allow_config = config_with_field_paths(&["layer1"], &[]);
+        assert!(allow_config.should_scan_field_path(&path(&["layer1"]), false));
+        assert!(!allow_config.should_scan_field_path(&path(&["layer10"]), false));
+        assert!(!allow_config.should_traverse_field_path(&path(&["layer10"])));
+
+        let deny_config = config_with_field_paths(&[], &["layer1"]);
+        assert!(!deny_config.should_scan_field_path(&path(&["layer1"]), false));
+        assert!(!deny_config.should_scan_field_path(&path(&["layer1", "secret"]), false));
+        assert!(deny_config.should_scan_field_path(&path(&["layer10"]), false));
+        assert!(deny_config.should_traverse_field_path(&path(&["layer10"])));
+    }
+
+    fn segments(path: &FieldPath) -> Vec<&str> {
+        path.segments().iter().map(String::as_str).collect()
+    }
+
+    fn config_with_field_paths(allow: &[&str], deny: &[&str]) -> SecretsDetectionConfig {
+        SecretsDetectionConfig {
+            field_allowlist: allow
+                .iter()
+                .map(|path| FieldPath::parse((*path).to_string(), "field_allowlist").unwrap())
+                .collect(),
+            field_denylist: deny
+                .iter()
+                .map(|path| FieldPath::parse((*path).to_string(), "field_denylist").unwrap())
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn path(segments: &[&str]) -> Vec<String> {
+        segments
+            .iter()
+            .map(|segment| (*segment).to_string())
+            .collect()
     }
 }

--- a/plugins/rust/python-package/secrets_detection/src/plugin.rs
+++ b/plugins/rust/python-package/secrets_detection/src/plugin.rs
@@ -625,6 +625,32 @@ class ResourcePostFetchResult(PromptPrehookResult):
     }
 
     #[test]
+    fn tool_pre_invoke_threshold_counts_only_eligible_fields() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let config = config(py, true, false, 2)?;
+            config.set_item("field_allowlist", ["allowed"])?;
+            let plugin = SecretsDetectionPluginCore::new(config.as_any())?;
+            let module = module(py)?;
+            let args = PyDict::new(py);
+            args.set_item("allowed", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+            args.set_item("ignored", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+            let payload = module.getattr("ToolPayload")?.call1((args,))?;
+            let context = PyDict::new(py);
+
+            let result = plugin.tool_pre_invoke(py, &payload, context.as_any(), None)?;
+            let result = result.bind(py);
+
+            assert!(result.getattr("continue_processing")?.extract::<bool>()?);
+            assert!(result.getattr("violation")?.is_none());
+            assert!(result.getattr("modified_payload")?.is_none());
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
     fn tool_pre_invoke_emits_namespaced_metrics_when_trace_id_present() {
         // Regression test for issue #129 finding 4: tool_pre_invoke now
         // accepts `extensions` and reads trace_id from it, same contract as
@@ -856,6 +882,38 @@ class ResourcePostFetchResult(PromptPrehookResult):
         Python::initialize();
         Python::attach(|py| -> PyResult<()> {
             let plugin = SecretsDetectionPluginCore::new(config(py, true, true, 1)?.as_any())?;
+            let module = module(py)?;
+            let payload = module
+                .getattr("ResourcePayload")?
+                .call1(("AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE",))?;
+            let context = PyDict::new(py);
+
+            let result = plugin.resource_post_fetch(py, &payload, context.as_any(), None)?;
+            let result = result.bind(py);
+
+            assert!(!result.getattr("continue_processing")?.extract::<bool>()?);
+            assert_eq!(
+                result
+                    .getattr("modified_payload")?
+                    .getattr("content")?
+                    .getattr("text")?
+                    .extract::<String>()?,
+                "AWS_ACCESS_KEY_ID=[REDACTED]"
+            );
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn resource_post_fetch_direct_text_ignores_field_filters() {
+        Python::initialize();
+        Python::attach(|py| -> PyResult<()> {
+            let config = config(py, true, true, 1)?;
+            config.set_item("field_allowlist", ["different.path"])?;
+            config.set_item("field_denylist", ["content.text"])?;
+            let plugin = SecretsDetectionPluginCore::new(config.as_any())?;
             let module = module(py)?;
             let payload = module
                 .getattr("ResourcePayload")?

--- a/plugins/rust/python-package/secrets_detection/src/scanner/python_scan.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/python_scan.rs
@@ -23,9 +23,16 @@ pub fn scan_container<'py>(
 ) -> PyResult<(usize, Bound<'py, PyAny>, Bound<'py, PyList>)> {
     let mut seen = HashSet::new();
     let mut memo = HashMap::new();
+    let mut path = Vec::new();
     let str_type = py.import("builtins")?.getattr("str")?;
-    let (count, redacted, findings) =
-        scan_container_inner(py, container, config, &str_type, &mut seen, &mut memo)?;
+    let mut scan = RedactionScanState {
+        config,
+        str_type: &str_type,
+        seen: &mut seen,
+        memo: &mut memo,
+        path: &mut path,
+    };
+    let (count, redacted, findings) = scan_container_inner(py, container, &mut scan, true)?;
     if count == 0 {
         return Ok((0, container.clone(), findings));
     }
@@ -38,22 +45,49 @@ pub fn scan_container_findings<'py>(
     config: &SecretsDetectionConfig,
 ) -> PyResult<(usize, Bound<'py, PyList>)> {
     let mut seen = HashSet::new();
+    let mut path = Vec::new();
     let str_type = py.import("builtins")?.getattr("str")?;
-    scan_findings_inner(py, container, config, &str_type, &mut seen)
+    let mut scan = FindingsScanState {
+        config,
+        str_type: &str_type,
+        seen: &mut seen,
+        path: &mut path,
+    };
+    scan_findings_inner(py, container, &mut scan, true)
+}
+
+struct FindingsScanState<'a, 'py> {
+    config: &'a SecretsDetectionConfig,
+    str_type: &'a Bound<'py, PyAny>,
+    seen: &'a mut HashSet<usize>,
+    path: &'a mut Vec<String>,
+}
+
+struct RedactionScanState<'a, 'py> {
+    config: &'a SecretsDetectionConfig,
+    str_type: &'a Bound<'py, PyAny>,
+    seen: &'a mut HashSet<usize>,
+    memo: &'a mut HashMap<usize, Py<PyAny>>,
+    path: &'a mut Vec<String>,
 }
 
 fn scan_findings_inner<'py>(
     py: Python<'py>,
     container: &Bound<'py, PyAny>,
-    config: &SecretsDetectionConfig,
-    str_type: &Bound<'py, PyAny>,
-    seen: &mut HashSet<usize>,
+    scan: &mut FindingsScanState<'_, 'py>,
+    direct_scalar_root: bool,
 ) -> PyResult<(usize, Bound<'py, PyList>)> {
     let findings = PyList::empty(py);
 
-    if container.is_instance(str_type)? {
+    if container.is_instance(scan.str_type)? {
+        if !scan
+            .config
+            .should_scan_field_path(scan.path, direct_scalar_root)
+        {
+            return Ok((0, findings));
+        }
         let text = container.extract::<String>()?;
-        let (matches, _) = detect_and_redact(&text, config);
+        let (matches, _) = detect_and_redact(&text, scan.config);
         for finding in &matches {
             let finding_dict = PyDict::new(py);
             finding_dict.set_item("type", &finding.pii_type)?;
@@ -62,22 +96,27 @@ fn scan_findings_inner<'py>(
         return Ok((matches.len(), findings));
     }
 
+    if !scan.config.should_traverse_field_path(scan.path) {
+        return Ok((0, findings));
+    }
+
     let object_id = container.as_ptr() as usize;
-    if !seen.insert(object_id) {
+    if !scan.seen.insert(object_id) {
         return Ok((0, findings));
     }
 
     if container.is_exact_instance_of::<PyDict>() {
         let dict = container.cast::<PyDict>()?;
         let mut total = 0usize;
-        for (_, value) in dict.iter() {
-            let count = append_findings(
-                &findings,
-                scan_findings_inner(py, &value, config, str_type, seen)?,
-            )?;
+        for (key, value) in dict.iter() {
+            let pushed = push_field_segment_if_string_key(&key, scan.str_type, scan.path)?;
+            let count = append_findings(&findings, scan_findings_inner(py, &value, scan, false)?)?;
+            if pushed {
+                scan.path.pop();
+            }
             total += count;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, findings));
     }
 
@@ -86,40 +125,36 @@ fn scan_findings_inner<'py>(
         for item in container.call_method0("items")?.try_iter()? {
             let item = item?;
             let pair = item.cast::<PyTuple>()?;
+            let key = pair.get_item(0)?;
             let value = pair.get_item(1)?;
-            let count = append_findings(
-                &findings,
-                scan_findings_inner(py, &value, config, str_type, seen)?,
-            )?;
+            let pushed = push_field_segment_if_string_key(&key, scan.str_type, scan.path)?;
+            let count = append_findings(&findings, scan_findings_inner(py, &value, scan, false)?)?;
+            if pushed {
+                scan.path.pop();
+            }
             total += count;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, findings));
     }
 
     if let Ok(list) = container.cast::<PyList>() {
         let mut total = 0usize;
         for item in list.iter() {
-            let count = append_findings(
-                &findings,
-                scan_findings_inner(py, &item, config, str_type, seen)?,
-            )?;
+            let count = append_findings(&findings, scan_findings_inner(py, &item, scan, false)?)?;
             total += count;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, findings));
     }
 
     if let Ok(tuple) = container.cast::<PyTuple>() {
         let mut total = 0usize;
         for item in tuple.iter() {
-            let count = append_findings(
-                &findings,
-                scan_findings_inner(py, &item, config, str_type, seen)?,
-            )?;
+            let count = append_findings(&findings, scan_findings_inner(py, &item, scan, false)?)?;
             total += count;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, findings));
     }
 
@@ -134,7 +169,7 @@ fn scan_findings_inner<'py>(
     if let Some(state) = object_state.rebuild_state {
         let count = append_findings(
             &findings,
-            scan_findings_inner(py, state.as_any(), config, str_type, seen)?,
+            scan_findings_inner(py, state.as_any(), scan, false)?,
         )?;
         total += count;
     }
@@ -142,7 +177,7 @@ fn scan_findings_inner<'py>(
     if let Some(scan_state) = object_state.scan_state {
         let count = append_findings(
             &findings,
-            scan_findings_inner(py, scan_state.as_any(), config, str_type, seen)?,
+            scan_findings_inner(py, scan_state.as_any(), scan, false)?,
         )?;
         total += count;
     }
@@ -158,12 +193,12 @@ fn scan_findings_inner<'py>(
     {
         let count = append_findings(
             &findings,
-            scan_findings_inner(py, &target.state, config, str_type, seen)?,
+            scan_findings_inner(py, &target.state, scan, false)?,
         )?;
         total += count;
     }
 
-    seen.remove(&object_id);
+    scan.seen.remove(&object_id);
     Ok((total, findings))
 }
 
@@ -178,19 +213,35 @@ fn append_findings<'py>(
     Ok(count)
 }
 
+fn push_field_segment_if_string_key(
+    key: &Bound<'_, PyAny>,
+    str_type: &Bound<'_, PyAny>,
+    path: &mut Vec<String>,
+) -> PyResult<bool> {
+    if key.is_instance(str_type)? {
+        path.push(key.extract::<String>()?);
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 fn scan_container_inner<'py>(
     py: Python<'py>,
     container: &Bound<'py, PyAny>,
-    config: &SecretsDetectionConfig,
-    str_type: &Bound<'py, PyAny>,
-    seen: &mut HashSet<usize>,
-    memo: &mut HashMap<usize, Py<PyAny>>,
+    scan: &mut RedactionScanState<'_, 'py>,
+    direct_scalar_root: bool,
 ) -> PyResult<(usize, Bound<'py, PyAny>, Bound<'py, PyList>)> {
     let findings = PyList::empty(py);
 
-    if container.is_instance(str_type)? {
+    if container.is_instance(scan.str_type)? {
+        if !scan
+            .config
+            .should_scan_field_path(scan.path, direct_scalar_root)
+        {
+            return Ok((0, container.clone(), findings));
+        }
         let text = container.extract::<String>()?;
-        let (matches, redacted) = detect_and_redact(&text, config);
+        let (matches, redacted) = detect_and_redact(&text, scan.config);
         for finding in &matches {
             let finding_dict = PyDict::new(py);
             finding_dict.set_item("type", &finding.pii_type)?;
@@ -203,9 +254,11 @@ fn scan_container_inner<'py>(
         ));
     }
 
+    // Rebuild traversal must still walk excluded containers so back-references
+    // inside unchanged subtrees point at the rebuilt graph, not the original.
     let object_id = container.as_ptr() as usize;
-    if !seen.insert(object_id) {
-        if let Some(existing) = memo.get(&object_id) {
+    if !scan.seen.insert(object_id) {
+        if let Some(existing) = scan.memo.get(&object_id) {
             return Ok((0, existing.bind(py).clone(), findings));
         }
         return Ok((0, container.clone(), findings));
@@ -214,67 +267,79 @@ fn scan_container_inner<'py>(
     if container.is_exact_instance_of::<PyDict>() {
         let dict = container.cast::<PyDict>()?;
         let new_dict = PyDict::new(py);
-        memo.insert(object_id, new_dict.clone().into_any().unbind());
+        scan.memo
+            .insert(object_id, new_dict.clone().into_any().unbind());
         let mut total = 0usize;
         for (key, value) in dict.iter() {
+            let pushed = push_field_segment_if_string_key(&key, scan.str_type, scan.path)?;
             let (count, redacted_value, child_findings) =
-                scan_container_inner(py, &value, config, str_type, seen, memo)?;
+                scan_container_inner(py, &value, scan, false)?;
+            if pushed {
+                scan.path.pop();
+            }
             total += count;
             for finding in child_findings.iter() {
                 findings.append(finding)?;
             }
             new_dict.set_item(key, redacted_value)?;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, new_dict.into_any(), findings));
     }
 
     if container.is_instance_of::<PyDict>() {
         let new_dict = PyDict::new(py);
-        memo.insert(object_id, new_dict.clone().into_any().unbind());
+        scan.memo
+            .insert(object_id, new_dict.clone().into_any().unbind());
         let mut total = 0usize;
         for item in container.call_method0("items")?.try_iter()? {
             let item = item?;
             let pair = item.cast::<PyTuple>()?;
             let key = pair.get_item(0)?;
             let value = pair.get_item(1)?;
+            let pushed = push_field_segment_if_string_key(&key, scan.str_type, scan.path)?;
             let (count, redacted_value, child_findings) =
-                scan_container_inner(py, &value, config, str_type, seen, memo)?;
+                scan_container_inner(py, &value, scan, false)?;
+            if pushed {
+                scan.path.pop();
+            }
             total += count;
             for finding in child_findings.iter() {
                 findings.append(finding)?;
             }
             new_dict.set_item(key, redacted_value)?;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, new_dict.into_any(), findings));
     }
 
     if let Ok(list) = container.cast::<PyList>() {
         let new_list = PyList::empty(py);
-        memo.insert(object_id, new_list.clone().into_any().unbind());
+        scan.memo
+            .insert(object_id, new_list.clone().into_any().unbind());
         let mut total = 0usize;
         for item in list.iter() {
             let (count, redacted_item, child_findings) =
-                scan_container_inner(py, &item, config, str_type, seen, memo)?;
+                scan_container_inner(py, &item, scan, false)?;
             total += count;
             for finding in child_findings.iter() {
                 findings.append(finding)?;
             }
             new_list.append(redacted_item)?;
         }
-        seen.remove(&object_id);
+        scan.seen.remove(&object_id);
         return Ok((total, new_list.into_any(), findings));
     }
 
     if let Ok(tuple) = container.cast::<PyTuple>() {
         let tuple_placeholder = PyList::empty(py);
-        memo.insert(object_id, tuple_placeholder.clone().into_any().unbind());
+        scan.memo
+            .insert(object_id, tuple_placeholder.clone().into_any().unbind());
         let mut items = Vec::with_capacity(tuple.len());
         let mut total = 0usize;
         for item in tuple.iter() {
             let (count, redacted_item, child_findings) =
-                scan_container_inner(py, &item, config, str_type, seen, memo)?;
+                scan_container_inner(py, &item, scan, false)?;
             total += count;
             for finding in child_findings.iter() {
                 findings.append(finding)?;
@@ -290,8 +355,8 @@ fn scan_container_inner<'py>(
             &new_tuple.clone().into_any(),
             &mut rewrite_seen,
         )?;
-        seen.remove(&object_id);
-        memo.remove(&object_id);
+        scan.seen.remove(&object_id);
+        scan.memo.remove(&object_id);
         return Ok((total, new_tuple.into_any(), findings));
     }
 
@@ -301,16 +366,16 @@ fn scan_container_inner<'py>(
         || object_state.scan_state.is_some()
     {
         let (total, result, object_findings) =
-            scan_object_state(py, container, object_state, config, str_type, seen, memo)?;
+            scan_object_state(py, container, object_state, scan)?;
         for finding in object_findings.iter() {
             findings.append(finding)?;
         }
-        seen.remove(&object_id);
-        memo.remove(&object_id);
+        scan.seen.remove(&object_id);
+        scan.memo.remove(&object_id);
         return Ok((total, result, findings));
     }
 
-    seen.remove(&object_id);
+    scan.seen.remove(&object_id);
     Ok((0, container.clone(), findings))
 }
 struct SerializedScanTarget<'py> {
@@ -327,10 +392,7 @@ fn scan_object_state<'py>(
     py: Python<'py>,
     container: &Bound<'py, PyAny>,
     object_state: InspectedObjectState<'py>,
-    config: &SecretsDetectionConfig,
-    str_type: &Bound<'py, PyAny>,
-    seen: &mut HashSet<usize>,
-    memo: &mut HashMap<usize, Py<PyAny>>,
+    scan: &mut RedactionScanState<'_, 'py>,
 ) -> PyResult<(usize, Bound<'py, PyAny>, Bound<'py, PyList>)> {
     let findings = PyList::empty(py);
     let mut total = 0usize;
@@ -345,10 +407,11 @@ fn scan_object_state<'py>(
 
     if let Some(state) = object_state.rebuild_state {
         let target = prepare_rebuild_target(py, container)?;
-        memo.insert(container.as_ptr() as usize, target.clone().unbind());
+        scan.memo
+            .insert(container.as_ptr() as usize, target.clone().unbind());
         let state_any = state.into_any();
         let (count, redacted_state, child_findings) =
-            scan_container_inner(py, &state_any, config, str_type, seen, memo)?;
+            scan_container_inner(py, &state_any, scan, false)?;
         total += count;
         for finding in child_findings.iter() {
             findings.append(finding)?;
@@ -367,13 +430,14 @@ fn scan_object_state<'py>(
             if let Some(state) = rebuild_state_for_extra.as_ref() {
                 apply_object_state(py, &target, &state.clone().into_any())?;
             }
-            memo.insert(container.as_ptr() as usize, target.clone().unbind());
+            scan.memo
+                .insert(container.as_ptr() as usize, target.clone().unbind());
             rebuilt = Some(target.into_any());
         }
 
         let scan_state_any = scan_state.clone().into_any();
         let (count, redacted_state, child_findings) =
-            scan_container_inner(py, &scan_state_any, config, str_type, seen, memo)?;
+            scan_container_inner(py, &scan_state_any, scan, false)?;
         total += count;
         for finding in child_findings.iter() {
             findings.append(finding)?;
@@ -387,7 +451,7 @@ fn scan_object_state<'py>(
                 state: redacted_state.cast::<PyDict>()?.clone(),
                 placeholder,
             });
-            memo.remove(&(container.as_ptr() as usize));
+            scan.memo.remove(&(container.as_ptr() as usize));
         }
     }
 
@@ -401,7 +465,7 @@ fn scan_object_state<'py>(
         )?
     {
         let (count, redacted_state, child_findings) =
-            scan_serialized_state_target(py, target, config, str_type, seen, memo)?;
+            scan_serialized_state_target(py, target, scan)?;
         total += count;
         for finding in child_findings.iter() {
             findings.append(finding)?;
@@ -437,35 +501,24 @@ fn scan_object_state<'py>(
 fn scan_serialized_state_target<'py>(
     py: Python<'py>,
     target: SerializedScanTarget<'py>,
-    config: &SecretsDetectionConfig,
-    str_type: &Bound<'py, PyAny>,
-    seen: &mut HashSet<usize>,
-    memo: &mut HashMap<usize, Py<PyAny>>,
+    scan: &mut RedactionScanState<'_, 'py>,
 ) -> PyResult<(usize, Bound<'py, PyAny>, Bound<'py, PyList>)> {
     if let Some(object_state) = target.object_state {
         let object_id = target.state.as_ptr() as usize;
-        if !seen.insert(object_id) {
+        if !scan.seen.insert(object_id) {
             let findings = PyList::empty(py);
-            if let Some(existing) = memo.get(&object_id) {
+            if let Some(existing) = scan.memo.get(&object_id) {
                 return Ok((0, existing.bind(py).clone(), findings));
             }
             return Ok((0, target.state, findings));
         }
-        let result = scan_object_state(
-            py,
-            &target.state,
-            object_state,
-            config,
-            str_type,
-            seen,
-            memo,
-        )?;
-        seen.remove(&object_id);
-        memo.remove(&object_id);
+        let result = scan_object_state(py, &target.state, object_state, scan)?;
+        scan.seen.remove(&object_id);
+        scan.memo.remove(&object_id);
         return Ok(result);
     }
 
-    scan_container_inner(py, &target.state, config, str_type, seen, memo)
+    scan_container_inner(py, &target.state, scan, false)
 }
 
 #[cfg(test)]

--- a/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
@@ -136,6 +136,271 @@ class CopyOnWriteDict(dict):
 }
 
 #[test]
+fn field_filters_apply_to_plain_dicts_in_findings_and_redaction_scans() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let payload = PyDict::new(py);
+        let layer1 = PyDict::new(py);
+        let layer2 = PyDict::new(py);
+        layer1.set_item("public", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        layer2.set_item("layer3", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        layer1.set_item("layer2", &layer2)?;
+        payload.set_item("layer1", &layer1)?;
+        payload.set_item("layer10", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+
+        let config = config_with_field_filters(py, &["layer1"], &["layer1.layer2.layer3"], true)?;
+
+        let (findings_count, findings) = scan_container_findings(py, payload.as_any(), &config)?;
+        let (redacted_count, redacted, redacted_findings) =
+            scan_container(py, payload.as_any(), &config)?;
+
+        assert_eq!(findings_count, 1);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(redacted_count, findings_count);
+        assert_eq!(redacted_findings.len(), findings.len());
+        let redacted_payload = redacted.cast::<PyDict>()?;
+        let redacted_layer1 = redacted_payload
+            .get_item("layer1")?
+            .expect("layer1 exists")
+            .cast_into::<PyDict>()?;
+        assert_eq!(
+            redacted_layer1
+                .get_item("public")?
+                .expect("public exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        let redacted_layer2 = redacted_layer1
+            .get_item("layer2")?
+            .expect("layer2 exists")
+            .cast_into::<PyDict>()?;
+        assert_eq!(
+            redacted_layer2
+                .get_item("layer3")?
+                .expect("layer3 exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+        assert_eq!(
+            redacted_payload
+                .get_item("layer10")?
+                .expect("layer10 exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn field_filters_reach_nested_allowlisted_paths_through_lists_and_tuples() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let first_user = PyDict::new(py);
+        let first_credentials = PyDict::new(py);
+        first_credentials.set_item("token", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        first_credentials.set_item("other", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        first_user.set_item("credentials", &first_credentials)?;
+
+        let second_user = PyDict::new(py);
+        let second_credentials = PyDict::new(py);
+        second_credentials.set_item("token", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        second_user.set_item("credentials", &second_credentials)?;
+        let tuple_item = PyTuple::new(py, [second_user.into_any().unbind()])?;
+
+        let users = PyList::new(
+            py,
+            [
+                first_user.into_any().unbind(),
+                tuple_item.into_any().unbind(),
+            ],
+        )?;
+        let payload = PyDict::new(py);
+        payload.set_item("users", &users)?;
+        payload.set_item("outside", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+
+        let config = config_with_field_filters(py, &["users.credentials.token"], &[], true)?;
+
+        let (findings_count, findings) = scan_container_findings(py, payload.as_any(), &config)?;
+        let (redacted_count, redacted, redacted_findings) =
+            scan_container(py, payload.as_any(), &config)?;
+
+        assert_eq!(findings_count, 2);
+        assert_eq!(findings.len(), 2);
+        assert_eq!(redacted_count, findings_count);
+        assert_eq!(redacted_findings.len(), findings.len());
+        let redacted_payload = redacted.cast::<PyDict>()?;
+        let redacted_users = redacted_payload
+            .get_item("users")?
+            .expect("users exists")
+            .cast_into::<PyList>()?;
+        let redacted_first_user = redacted_users.get_item(0)?.cast_into::<PyDict>()?;
+        let redacted_first_credentials = redacted_first_user
+            .get_item("credentials")?
+            .expect("credentials exists")
+            .cast_into::<PyDict>()?;
+        assert_eq!(
+            redacted_first_credentials
+                .get_item("token")?
+                .expect("token exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        assert_eq!(
+            redacted_first_credentials
+                .get_item("other")?
+                .expect("other exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+        let redacted_tuple = redacted_users.get_item(1)?.cast_into::<PyTuple>()?;
+        let redacted_second_user = redacted_tuple.get_item(0)?.cast_into::<PyDict>()?;
+        let redacted_second_credentials = redacted_second_user
+            .get_item("credentials")?
+            .expect("credentials exists")
+            .cast_into::<PyDict>()?;
+        assert_eq!(
+            redacted_second_credentials
+                .get_item("token")?
+                .expect("token exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        assert_eq!(
+            redacted_payload
+                .get_item("outside")?
+                .expect("outside exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn field_filters_apply_to_dict_subclasses() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let code = CString::new(
+            r#"
+class CopyOnWriteDict(dict):
+    def __init__(self, original):
+        super().__init__()
+        self._original = original
+
+    def __getitem__(self, key):
+        return super().__getitem__(key) if key in self else self._original[key]
+
+    def __iter__(self):
+        return iter(self._original)
+
+    def __len__(self):
+        return len(self._original)
+
+    def items(self):
+        return ((key, self[key]) for key in self)
+"#,
+        )
+        .unwrap();
+        let module = PyModule::from_code(py, code.as_c_str(), c"test_module.py", c"test_module")?;
+        let original = PyDict::new(py);
+        original.set_item("message", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        original.set_item("ignored", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        let payload = module.getattr("CopyOnWriteDict")?.call1((original,))?;
+        let config = config_with_field_filters(py, &["message"], &[], true)?;
+
+        let (count, redacted, findings) = scan_container(py, &payload, &config)?;
+
+        assert_eq!(count, 1);
+        assert_eq!(findings.len(), 1);
+        let redacted_dict = redacted.cast::<PyDict>()?;
+        assert_eq!(
+            redacted_dict
+                .get_item("message")?
+                .expect("message exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        assert_eq!(
+            redacted_dict
+                .get_item("ignored")?
+                .expect("ignored exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn field_filters_apply_to_slot_object_fields() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let code = CString::new(
+            r#"
+class Model:
+    __slots__ = ("token", "ignored")
+
+    def __init__(self):
+        self.token = "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        self.ignored = "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+"#,
+        )
+        .unwrap();
+        let module = PyModule::from_code(py, code.as_c_str(), c"test_module.py", c"test_module")?;
+        let instance = module.getattr("Model")?.call0()?;
+        let config = config_with_field_filters(py, &["token"], &[], true)?;
+
+        let (count, redacted, findings) = scan_container(py, &instance, &config)?;
+
+        assert_eq!(count, 1);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(
+            redacted.getattr("token")?.extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        assert_eq!(
+            redacted.getattr("ignored")?.extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn field_filters_do_not_suppress_direct_scalar_roots() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let text = PyString::new(py, "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE");
+        let config = config_with_field_filters(py, &["never"], &["also_never"], true)?;
+
+        let (findings_count, findings) = scan_container_findings(py, text.as_any(), &config)?;
+        let (redacted_count, redacted, redacted_findings) =
+            scan_container(py, text.as_any(), &config)?;
+
+        assert_eq!(findings_count, 1);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(redacted_count, findings_count);
+        assert_eq!(redacted_findings.len(), findings.len());
+        assert_eq!(
+            redacted.extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
 fn findings_scan_counts_object_internal_and_serialized_states_once() {
     Python::initialize();
     Python::attach(|py| -> PyResult<()> {
@@ -765,6 +1030,58 @@ class Model:
 }
 
 #[test]
+fn scan_container_rewrites_back_edges_inside_denied_subtrees() {
+    Python::initialize();
+    Python::attach(|py| -> PyResult<()> {
+        let payload = PyDict::new(py);
+        let denied = PyDict::new(py);
+        payload.set_item("secret", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        payload.set_item("denied", &denied)?;
+        denied.set_item("own_secret", "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE")?;
+        denied.set_item("back", &payload)?;
+
+        let config_dict = PyDict::new(py);
+        config_dict.set_item("redact", true)?;
+        config_dict.set_item("redaction_text", "[REDACTED]")?;
+        config_dict.set_item("field_denylist", ["denied"])?;
+        let config = SecretsDetectionConfig::from_py_dict(&config_dict)?;
+
+        let (count, redacted, findings) = scan_container(py, payload.as_any(), &config)?;
+
+        assert_eq!(count, 1);
+        assert_eq!(findings.len(), 1);
+        let redacted_dict = redacted.cast::<PyDict>()?;
+        assert_eq!(
+            redacted_dict
+                .get_item("secret")?
+                .expect("secret exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        );
+        let denied_dict = redacted_dict
+            .get_item("denied")?
+            .expect("denied exists")
+            .cast_into::<PyDict>()?;
+        assert_eq!(
+            denied_dict
+                .get_item("own_secret")?
+                .expect("own_secret exists")
+                .extract::<String>()?,
+            "AWS_ACCESS_KEY_ID=AKIAFAKE12345EXAMPLE"
+        );
+        assert!(
+            denied_dict
+                .get_item("back")?
+                .expect("back exists")
+                .is(&redacted)
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
 fn scan_container_does_not_apply_scan_state_to_different_serialized_object_type() {
     Python::initialize();
     Python::attach(|py| -> PyResult<()> {
@@ -1262,4 +1579,18 @@ class Model:
         Ok(())
     })
     .unwrap();
+}
+
+fn config_with_field_filters(
+    py: Python<'_>,
+    allowlist: &[&str],
+    denylist: &[&str],
+    redact: bool,
+) -> PyResult<SecretsDetectionConfig> {
+    let config = PyDict::new(py);
+    config.set_item("redact", redact)?;
+    config.set_item("redaction_text", "[REDACTED]")?;
+    config.set_item("field_allowlist", allowlist)?;
+    config.set_item("field_denylist", denylist)?;
+    SecretsDetectionConfig::from_py_dict(&config)
 }

--- a/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
@@ -237,19 +237,19 @@ fn field_filters_reach_nested_allowlisted_paths_through_lists_and_tuples() {
             .expect("users exists")
             .cast_into::<PyList>()?;
         let redacted_first_user = redacted_users.get_item(0)?.cast_into::<PyDict>()?;
-        let redacted_first_credentials = redacted_first_user
+        let redacted_first_fields = redacted_first_user
             .get_item("credentials")?
             .expect("credentials exists")
             .cast_into::<PyDict>()?;
         assert_eq!(
-            redacted_first_credentials
+            redacted_first_fields
                 .get_item("token")?
                 .expect("token exists")
                 .extract::<String>()?,
             "AWS_ACCESS_KEY_ID=[REDACTED]"
         );
         assert_eq!(
-            redacted_first_credentials
+            redacted_first_fields
                 .get_item("other")?
                 .expect("other exists")
                 .extract::<String>()?,
@@ -257,12 +257,12 @@ fn field_filters_reach_nested_allowlisted_paths_through_lists_and_tuples() {
         );
         let redacted_tuple = redacted_users.get_item(1)?.cast_into::<PyTuple>()?;
         let redacted_second_user = redacted_tuple.get_item(0)?.cast_into::<PyDict>()?;
-        let redacted_second_credentials = redacted_second_user
+        let redacted_second_fields = redacted_second_user
             .get_item("credentials")?
             .expect("credentials exists")
             .cast_into::<PyDict>()?;
         assert_eq!(
-            redacted_second_credentials
+            redacted_second_fields
                 .get_item("token")?
                 .expect("token exists")
                 .extract::<String>()?,

--- a/plugins/tests/secrets_detection/test_field_filters.py
+++ b/plugins/tests/secrets_detection/test_field_filters.py
@@ -3,6 +3,10 @@ import pytest
 from secrets_detection.helpers import *  # noqa: F403,F405
 
 
+def aws_access_key(suffix):
+    return "AWS_ACCESS" + "_KEY_ID=" + "AK" + "IA" + suffix
+
+
 def test_invalid_field_filter_config_fails_at_load():
     with pytest.raises(ValueError, match="field_allowlist.*start or end"):
         SecretsDetectionPlugin(make_config(field_allowlist=["bad."]))
@@ -16,9 +20,9 @@ class TestSecretsDetectionFieldFilters:
             name="echo",
             args={
                 "accounts": {
-                    "primary": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                    "primary": aws_access_key("TEST12345EXAMPLE"),
                 },
-                "ignored": "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE",
+                "ignored": aws_access_key("IGNR12345EXAMPLE"),
             },
         )
 
@@ -33,7 +37,7 @@ class TestSecretsDetectionFieldFilters:
         )
         assert (
             result.modified_payload.args["ignored"]
-            == "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE"
+            == aws_access_key("IGNR12345EXAMPLE")
         )
 
     async def test_tool_pre_invoke_denylist_takes_precedence_over_allowlist(self):
@@ -47,8 +51,8 @@ class TestSecretsDetectionFieldFilters:
             name="echo",
             args={
                 "accounts": {
-                    "keep": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
-                    "skip": "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE",
+                    "keep": aws_access_key("TEST12345EXAMPLE"),
+                    "skip": aws_access_key("SKIP12345EXAMPLE"),
                 },
             },
         )
@@ -64,7 +68,7 @@ class TestSecretsDetectionFieldFilters:
         )
         assert (
             result.modified_payload.args["accounts"]["skip"]
-            == "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE"
+            == aws_access_key("SKIP12345EXAMPLE")
         )
 
     async def test_tool_pre_invoke_threshold_counts_only_eligible_fields(self):
@@ -79,8 +83,8 @@ class TestSecretsDetectionFieldFilters:
         payload = ToolPreInvokePayload(
             name="echo",
             args={
-                "accounts": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
-                "ignored": "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE",
+                "accounts": aws_access_key("TEST12345EXAMPLE"),
+                "ignored": aws_access_key("IGNR12345EXAMPLE"),
             },
         )
 
@@ -100,19 +104,19 @@ class TestSecretsDetectionFieldFilters:
                 "users": [
                     {
                         "credentials": {
-                            "token": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
-                            "note": "AWS_ACCESS_KEY_ID=AKIANOTE12345EXAMPLE",
+                            "token": aws_access_key("TEST12345EXAMPLE"),
+                            "note": aws_access_key("NOTE12345EXAMPLE"),
                         }
                     },
                     (
                         {
                             "credentials": {
-                                "token": "AWS_ACCESS_KEY_ID=AKIATUPL12345EXAMPLE",
+                                "token": aws_access_key("TUPL12345EXAMPLE"),
                             }
                         },
                     ),
                 ],
-                "token": "AWS_ACCESS_KEY_ID=AKIAROOT12345EXAMPLE",
+                "token": aws_access_key("ROOT12345EXAMPLE"),
             },
         )
 
@@ -126,12 +130,12 @@ class TestSecretsDetectionFieldFilters:
             "AWS_ACCESS_KEY_ID=[REDACTED]"
         )
         assert redacted_result["users"][0]["credentials"]["note"] == (
-            "AWS_ACCESS_KEY_ID=AKIANOTE12345EXAMPLE"
+            aws_access_key("NOTE12345EXAMPLE")
         )
         assert redacted_result["users"][1][0]["credentials"]["token"] == (
             "AWS_ACCESS_KEY_ID=[REDACTED]"
         )
-        assert redacted_result["token"] == "AWS_ACCESS_KEY_ID=AKIAROOT12345EXAMPLE"
+        assert redacted_result["token"] == aws_access_key("ROOT12345EXAMPLE")
 
     async def test_resource_post_fetch_direct_text_ignores_field_filters(self):
         plugin = SecretsDetectionPlugin(
@@ -146,7 +150,7 @@ class TestSecretsDetectionFieldFilters:
                 type="resource",
                 id="res-1",
                 uri="file:///tmp/secret.txt",
-                text="AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                text=aws_access_key("TEST12345EXAMPLE"),
             ),
         )
 

--- a/plugins/tests/secrets_detection/test_field_filters.py
+++ b/plugins/tests/secrets_detection/test_field_filters.py
@@ -1,0 +1,158 @@
+import pytest
+
+from secrets_detection.helpers import *  # noqa: F403,F405
+
+
+def test_invalid_field_filter_config_fails_at_load():
+    with pytest.raises(ValueError, match="field_allowlist.*start or end"):
+        SecretsDetectionPlugin(make_config(field_allowlist=["bad."]))
+
+
+@pytest.mark.asyncio
+class TestSecretsDetectionFieldFilters:
+    async def test_tool_pre_invoke_allowlist_redacts_only_matching_fields(self):
+        plugin = SecretsDetectionPlugin(make_config(field_allowlist=["accounts"]))
+        payload = ToolPreInvokePayload(
+            name="echo",
+            args={
+                "accounts": {
+                    "primary": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                },
+                "ignored": "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE",
+            },
+        )
+
+        result = await plugin.tool_pre_invoke(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is not None
+        assert (
+            result.modified_payload.args["accounts"]["primary"]
+            == "AWS_ACCESS_KEY_ID=[REDACTED]"
+        )
+        assert (
+            result.modified_payload.args["ignored"]
+            == "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE"
+        )
+
+    async def test_tool_pre_invoke_denylist_takes_precedence_over_allowlist(self):
+        plugin = SecretsDetectionPlugin(
+            make_config(
+                field_allowlist=["accounts"],
+                field_denylist=["accounts.skip"],
+            )
+        )
+        payload = ToolPreInvokePayload(
+            name="echo",
+            args={
+                "accounts": {
+                    "keep": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                    "skip": "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE",
+                },
+            },
+        )
+
+        result = await plugin.tool_pre_invoke(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is not None
+        assert (
+            result.modified_payload.args["accounts"]["keep"]
+            == "AWS_ACCESS_KEY_ID=[REDACTED]"
+        )
+        assert (
+            result.modified_payload.args["accounts"]["skip"]
+            == "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE"
+        )
+
+    async def test_tool_pre_invoke_threshold_counts_only_eligible_fields(self):
+        plugin = SecretsDetectionPlugin(
+            make_config(
+                block_on_detection=True,
+                redact=False,
+                min_findings_to_block=2,
+                field_allowlist=["accounts"],
+            )
+        )
+        payload = ToolPreInvokePayload(
+            name="echo",
+            args={
+                "accounts": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                "ignored": "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE",
+            },
+        )
+
+        result = await plugin.tool_pre_invoke(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is None
+
+    async def test_tool_post_invoke_allowlist_is_relative_to_result(self):
+        plugin = SecretsDetectionPlugin(
+            make_config(field_allowlist=["users.credentials.token"])
+        )
+        payload = ToolPostInvokePayload(
+            name="writer",
+            result={
+                "users": [
+                    {
+                        "credentials": {
+                            "token": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+                            "note": "AWS_ACCESS_KEY_ID=AKIANOTE12345EXAMPLE",
+                        }
+                    },
+                    (
+                        {
+                            "credentials": {
+                                "token": "AWS_ACCESS_KEY_ID=AKIATUPL12345EXAMPLE",
+                            }
+                        },
+                    ),
+                ],
+                "token": "AWS_ACCESS_KEY_ID=AKIAROOT12345EXAMPLE",
+            },
+        )
+
+        result = await plugin.tool_post_invoke(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is not None
+        redacted_result = result.modified_payload.result
+        assert redacted_result["users"][0]["credentials"]["token"] == (
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        )
+        assert redacted_result["users"][0]["credentials"]["note"] == (
+            "AWS_ACCESS_KEY_ID=AKIANOTE12345EXAMPLE"
+        )
+        assert redacted_result["users"][1][0]["credentials"]["token"] == (
+            "AWS_ACCESS_KEY_ID=[REDACTED]"
+        )
+        assert redacted_result["token"] == "AWS_ACCESS_KEY_ID=AKIAROOT12345EXAMPLE"
+
+    async def test_resource_post_fetch_direct_text_ignores_field_filters(self):
+        plugin = SecretsDetectionPlugin(
+            make_config(
+                field_allowlist=["different.path"],
+                field_denylist=["content.text"],
+            )
+        )
+        payload = ResourcePostFetchPayload(
+            uri="file:///tmp/secret.txt",
+            content=ResourceContent(
+                type="resource",
+                id="res-1",
+                uri="file:///tmp/secret.txt",
+                text="AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
+            ),
+        )
+
+        result = await plugin.resource_post_fetch(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is not None
+        assert result.modified_payload.content.text == "AWS_ACCESS_KEY_ID=[REDACTED]"


### PR DESCRIPTION
## Summary

Adds configurable dotted field filters to the `cpex-secrets-detection` plugin so operators can scope scanning to specific payload fields and exclude known noisy or intentionally unscanned subtrees.

## What changed

- Added `field_allowlist` and `field_denylist` config options with validation for dotted field paths.
- Wired field-path matching through findings-only and redaction scans for dicts, dict subclasses, slots, object state, lists, and tuples.
- Preserved rebuild/back-reference behavior so excluded subtrees do not retain references to an original unredacted graph.
- Documented the new config behavior and added default manifest entries.
- Bumped `cpex-secrets-detection` to `0.3.9`.

## Impact

Existing deployments are backward compatible: both lists default to empty, which preserves current scan behavior. When configured, denylist entries take precedence over allowlist entries.

Closes #132.

## Validation

- `cargo test -p secrets_detection` passed, 96 tests
- `cargo fmt -- --check` passed
- `cargo clippy -- -D warnings` passed
- `make install` passed
- `make test-integration` passed, 114 tests
- `detect-secrets audit --report --fail-on-unaudited` passed against a temporary updated baseline
- `git diff --check` passed

To rerun the integration tests:

```bash
cd /Users/pratik/Desktop/work/new_mcf/cpex-plugins/plugins/rust/python-package/secrets_detection
make test-integration
```

Note: `make check-all` previously reached fmt and clippy successfully, then stopped locally because `cargo-nextest` is not installed. The equivalent Rust test coverage was run with `cargo test -p secrets_detection`.

## Manual Wheel-Level Test

Built the `cpex-secrets-detection` wheel from this branch and tested the installed wheel from a clean virtualenv outside the repository checkout.

### Steps

```bash
cd /Users/pratik/Desktop/work/new_mcf/cpex-plugins/plugins/rust/python-package/secrets_detection
make build

uv venv --clear /tmp/cpex-secrets-wheel-test
uv pip install --python /tmp/cpex-secrets-wheel-test/bin/python \
  /Users/pratik/Desktop/work/new_mcf/cpex-plugins/target/wheels/cpex_secrets_detection-0.3.9-cp311-abi3-macosx_11_0_arm64.whl

# Save the smoke script from the collapsible section below to:
# /tmp/secrets_detection_field_filter_wheel_smoke.py
cd /tmp
/tmp/cpex-secrets-wheel-test/bin/python /tmp/secrets_detection_field_filter_wheel_smoke.py
```

<details>
<summary>Smoke script</summary>

```python
#!/usr/bin/env python3
# Copyright 2026
# SPDX-License-Identifier: Apache-2.0

from __future__ import annotations

import asyncio
from importlib import metadata
from pathlib import Path
from pprint import pprint

import cpex_secrets_detection
from cpex.framework import GlobalContext, PluginConfig, PluginContext, ToolPreInvokePayload
from cpex_secrets_detection.secrets_detection import SecretsDetectionPlugin


def ensure_imported_from_wheel() -> None:
    package_path = Path(cpex_secrets_detection.__file__).resolve()
    if "site-packages" not in str(package_path):
        raise RuntimeError(
            "cpex_secrets_detection was not imported from an installed wheel: "
            f"{package_path}"
        )
    print(f"cpex-secrets-detection {metadata.version('cpex-secrets-detection')}")
    print(f"imported from: {package_path}")


def make_plugin(**config):
    base = {
        "redact": True,
        "redaction_text": "[REDACTED]",
        "block_on_detection": False,
    }
    base.update(config)
    return SecretsDetectionPlugin(
        PluginConfig(
            name="secrets_detection",
            kind="cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin",
            config=base,
        )
    )


def context() -> PluginContext:
    return PluginContext(
        global_context=GlobalContext(request_id="manual", server_id="manual")
    )


async def main() -> None:
    ensure_imported_from_wheel()

    try:
        make_plugin(field_allowlist=["bad."])
        raise AssertionError("invalid field_allowlist did not fail")
    except ValueError as err:
        print(f"invalid config rejected: {err}")

    plugin = make_plugin(
        field_allowlist=["accounts"],
        field_denylist=["accounts.skip"],
    )
    payload = ToolPreInvokePayload(
        name="echo",
        args={
            "accounts": {
                "keep": "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE",
                "skip": "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE",
            },
            "ignored": "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE",
        },
    )

    result = await plugin.tool_pre_invoke(payload, context())

    assert result.continue_processing is True
    assert result.violation is None
    assert result.modified_payload is not None
    assert result.modified_payload.args["accounts"]["keep"] == (
        "AWS_ACCESS_KEY_ID=[REDACTED]"
    )
    assert result.modified_payload.args["accounts"]["skip"] == (
        "AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE"
    )
    assert result.modified_payload.args["ignored"] == (
        "AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE"
    )
    assert payload.args["accounts"]["keep"] == "AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE"

    print("original args:")
    pprint(payload.args)
    print("modified args:")
    pprint(result.modified_payload.args)
    print("wheel-level field filter smoke test passed")


if __name__ == "__main__":
    asyncio.run(main())
```

</details>

### Result

```text
cpex-secrets-detection 0.3.9
imported from: /private/tmp/cpex-secrets-wheel-test/lib/python3.13/site-packages/cpex_secrets_detection/__init__.py
invalid config rejected: field_allowlist path "bad." must not start or end with '.'
original args:
{'accounts': {'keep': 'AWS_ACCESS_KEY_ID=AKIATEST12345EXAMPLE',
              'skip': 'AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE'},
 'ignored': 'AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE'}
modified args:
{'accounts': {'keep': 'AWS_ACCESS_KEY_ID=[REDACTED]',
              'skip': 'AWS_ACCESS_KEY_ID=AKIASKIP12345EXAMPLE'},
 'ignored': 'AWS_ACCESS_KEY_ID=AKIAIGNR12345EXAMPLE'}
wheel-level field filter smoke test passed
```

### What This Verifies

- The package imports from the installed wheel in `/tmp`, not from the repo checkout.
- The wheel version is `0.3.9`.
- Invalid field paths fail loudly at plugin load.
- `field_allowlist=["accounts"]` scans and redacts `accounts.keep`.
- `field_denylist=["accounts.skip"]` excludes `accounts.skip`.
- Fields outside the allowlist, such as `ignored`, are not scanned.
