### PR TITLE
Enforce Cargo workspace dependency policy

### DIFF
--- a/.github/workflows/ci-rust-python-package.yaml
+++ b/.github/workflows/ci-rust-python-package.yaml
@@ -193,7 +193,7 @@ jobs:
         run: cargo install cargo-deny@0.19.0 --locked
 
       - name: Run cargo deny
-        run: cargo deny check --config deny.toml
+        run: cargo deny --all-features check --config deny.toml
 
   mutation-testing:
     needs: validate-and-detect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,17 @@ license = "Apache-2.0"
 repository = "https://github.com/IBM/cpex-plugins"
 
 [workspace.dependencies]
+# Keep dependencies here only when at least two workspace members inherit them.
 cpex_framework_bridge = { path = "crates/framework_bridge" }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 log = "0.4.29"
-pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
+mutants = "0.0.4"
 pyo3 = { version = "0.29.0", features = ["abi3-py311"] }
 pyo3-log = "0.13.4"
 pyo3-stub-gen = "0.23.0"
 regex = "1.12.3"
 serde_json = "1.0.149"
 thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["full"] }
-rand = "0.10.1"
 serde = { version = "1.0.228", features = ["derive"] }
 
 [profile.release]

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,11 @@ ignore = [
     "RUSTSEC-2025-0100", # unic-ucd-ident via rustpython-parser
 ]
 
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = true
+unused = "deny"
+
 [licenses]
 # Listed licenses are allowed even if not encountered in the dependency tree.
 unused-allowed-license = "allow"

--- a/plugins/rust/python-package/rate_limiter/Cargo.toml
+++ b/plugins/rust/python-package/rate_limiter/Cargo.toml
@@ -24,17 +24,17 @@ stub-gen = ["dep:pyo3-stub-gen"]
 cpex_framework_bridge = { workspace = true }
 log = { workspace = true }
 pyo3 = { workspace = true }
-pyo3-async-runtimes = { workspace = true }
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 pyo3-stub-gen = { workspace = true, optional = true }
 pyo3-log = { workspace = true }
-mutants = "0.0.4"
+mutants = { workspace = true }
 parking_lot = "0.12.5"
 thiserror = { workspace = true }
 redis = { version = "1.2.1", features = ["aio", "tokio-comp", "tls-rustls", "tls-rustls-insecure", "tokio-rustls-comp"] }
 # Enable default features (includes tls12 for TLS 1.2 support) plus the ring provider.
 rustls = { version = "0.23.40", features = ["ring"] }
 rustls-pki-types = "1.14"
-tokio = { workspace = true }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [dev-dependencies]
 rcgen = { version = "0.12", default-features = false, features = ["ring", "pem"] }

--- a/plugins/rust/python-package/retry_with_backoff/Cargo.toml
+++ b/plugins/rust/python-package/retry_with_backoff/Cargo.toml
@@ -25,10 +25,10 @@ cpex_framework_bridge = { workspace = true }
 log.workspace = true
 # mutants must be a regular (non-dev) dependency because #[mutants::skip] is
 # used in non-test code; moving it to dev-dependencies would break release builds.
-mutants = "0.0.4"
+mutants.workspace = true
 pyo3.workspace = true
 pyo3-log.workspace = true
 pyo3-stub-gen = { workspace = true, optional = true }
-rand.workspace = true
+rand = "0.10.1"
 serde.workspace = true
 serde_json.workspace = true

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -286,16 +286,17 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertIn("cpex_framework_bridge", workspace_deps)
         self.assertIn("criterion", workspace_deps)
         self.assertIn("log", workspace_deps)
-        self.assertIn("pyo3-async-runtimes", workspace_deps)
+        self.assertIn("mutants", workspace_deps)
         self.assertIn("pyo3", workspace_deps)
         self.assertIn("pyo3-log", workspace_deps)
         self.assertIn("pyo3-stub-gen", workspace_deps)
-        self.assertIn("rand", workspace_deps)
         self.assertIn("regex", workspace_deps)
         self.assertIn("serde", workspace_deps)
         self.assertIn("serde_json", workspace_deps)
         self.assertIn("thiserror", workspace_deps)
-        self.assertIn("tokio", workspace_deps)
+        self.assertNotIn("pyo3-async-runtimes", workspace_deps)
+        self.assertNotIn("rand", workspace_deps)
+        self.assertNotIn("tokio", workspace_deps)
 
         expected_plugin_deps = {
             "encoded_exfil_detection": {
@@ -332,12 +333,11 @@ class PluginCatalogTests(unittest.TestCase):
                 "dependencies": {
                     "cpex_framework_bridge": {"workspace": True},
                     "log": {"workspace": True},
+                    "mutants": {"workspace": True},
                     "pyo3": {"workspace": True},
-                    "pyo3-async-runtimes": {"workspace": True},
                     "pyo3-log": {"workspace": True},
                     "pyo3-stub-gen": {"workspace": True, "optional": True},
                     "thiserror": {"workspace": True},
-                    "tokio": {"workspace": True},
                 },
                 "dev-dependencies": {
                     "criterion": {"workspace": True},
@@ -347,10 +347,10 @@ class PluginCatalogTests(unittest.TestCase):
                 "dependencies": {
                     "cpex_framework_bridge": {"workspace": True},
                     "log": {"workspace": True},
+                    "mutants": {"workspace": True},
                     "pyo3": {"workspace": True},
                     "pyo3-log": {"workspace": True},
                     "pyo3-stub-gen": {"workspace": True, "optional": True},
-                    "rand": {"workspace": True},
                     "serde": {"workspace": True},
                     "serde_json": {"workspace": True},
                 },
@@ -2996,7 +2996,7 @@ class PluginCatalogTests(unittest.TestCase):
         self.assertNotIn("cargo-audit", security_section)
         self.assertNotIn("cargo audit", security_section)
         self.assertIn("cargo install cargo-deny", security_section)
-        self.assertEqual("cargo deny check --config deny.toml\n", deny_run)
+        self.assertEqual("cargo deny --all-features check --config deny.toml\n", deny_run)
         self.assertNotIn("-A unmaintained", security_section)
         self.assertNotIn("--workspace", security_section)
         self.assertNotIn("--manifest-path", security_section)

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -42,16 +42,14 @@ REQUIRED_WORKSPACE_DEPENDENCIES = {
     "cpex_framework_bridge",
     "criterion",
     "log",
-    "pyo3-async-runtimes",
+    "mutants",
     "pyo3",
     "pyo3-log",
     "pyo3-stub-gen",
-    "rand",
     "regex",
     "serde",
     "serde_json",
     "thiserror",
-    "tokio",
 }
 REQUIRED_PLUGIN_WORKSPACE_DEPENDENCIES = {
     "encoded_exfil_detection": {
@@ -84,12 +82,11 @@ REQUIRED_PLUGIN_WORKSPACE_DEPENDENCIES = {
         "dependencies": (
             "cpex_framework_bridge",
             "log",
+            "mutants",
             "pyo3",
-            "pyo3-async-runtimes",
             "pyo3-stub-gen",
             "pyo3-log",
             "thiserror",
-            "tokio",
         ),
         "dev-dependencies": ("criterion",),
     },
@@ -97,10 +94,10 @@ REQUIRED_PLUGIN_WORKSPACE_DEPENDENCIES = {
         "dependencies": (
             "cpex_framework_bridge",
             "log",
+            "mutants",
             "pyo3",
             "pyo3-log",
             "pyo3-stub-gen",
-            "rand",
             "serde",
             "serde_json",
         ),


### PR DESCRIPTION
## Summary

- configure cargo-deny to reject duplicated direct workspace dependencies and unused `[workspace.dependencies]` entries, including internal path dependencies
- run cargo-deny with all features so optional shared dependencies such as `pyo3-stub-gen` are included in the dependency graph
- centralize `mutants`, which is shared by two plugins
- keep `pyo3-async-runtimes`, `tokio`, and `rand` local to the single plugin that uses each dependency
- update the plugin catalog validator and regression tests to enforce the same ownership rules

## Why

The repository already centralized most shared dependency requirements, but CI did not enforce that shared direct dependencies use workspace inheritance or that workspace entries remain in use. Enabling cargo-deny's workspace dependency checks exposed the duplicated `mutants` declaration and ensures future drift fails CI.

This changes dependency declaration ownership only; resolved versions and plugin behavior are unchanged.

## Validation

- `cargo deny --all-features check --config deny.toml`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo +1.96.1 clippy --workspace --all-features -- -D warnings`
- `cargo test -p rate_limiter -p retry_with_backoff --all-features`
- `make plugins-validate` (124 passed, 3 skipped)
- `git diff --check`
