### PR TITLE
fix(retry_with_backoff): read result via mapping protocol so CopyOnWriteDict works (#136)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,7 +1565,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "retry_with_backoff"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "cpex_framework_bridge",
  "log",

--- a/plugins/rust/python-package/retry_with_backoff/Cargo.toml
+++ b/plugins/rust/python-package/retry_with_backoff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "retry_with_backoff"
-version = "0.3.6"
+version = "0.3.7"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/plugin-manifest.yaml
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "High-performance retry policy engine with exponential backoff, jitter, per-tool overrides, and retry metadata for transient tool and resource failures - Rust-majority architecture (95% Rust / 5% Python)"
 author: "ContextForge Contributors"
-version: "0.3.6"
+version: "0.3.7"
 kind: "cpex_retry_with_backoff.retry_with_backoff.RetryWithBackoffPlugin"
 available_hooks:
   - "tool_post_invoke"

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
@@ -50,7 +50,7 @@ class RetryWithBackoffPlugin(Plugin):
                     override["max_retries"] = ceiling
 
         self._core = RetryWithBackoffPluginCore(raw_cfg)
-        log.info("retry_with_backoff: Initialized with Rust core (v0.3.2)")
+        log.info("retry_with_backoff: Initialized with Rust core (v0.3.7)")
 
     async def tool_post_invoke(
         self,

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff.py
@@ -16,6 +16,7 @@ from cpex.framework import (
 )
 from cpex.framework.settings import get_settings
 
+from cpex_retry_with_backoff.retry_with_backoff_rust import __version__ as _RUST_CORE_VERSION
 from cpex_retry_with_backoff.retry_with_backoff_rust import RetryWithBackoffPluginCore
 
 log = logging.getLogger(__name__)
@@ -50,7 +51,7 @@ class RetryWithBackoffPlugin(Plugin):
                     override["max_retries"] = ceiling
 
         self._core = RetryWithBackoffPluginCore(raw_cfg)
-        log.info("retry_with_backoff: Initialized with Rust core (v0.3.7)")
+        log.info("retry_with_backoff: Initialized with Rust core (v%s)", _RUST_CORE_VERSION)
 
     async def tool_post_invoke(
         self,

--- a/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff_rust/__init__.pyi
+++ b/plugins/rust/python-package/retry_with_backoff/cpex_retry_with_backoff/retry_with_backoff_rust/__init__.pyi
@@ -6,7 +6,13 @@ import typing
 __all__ = [
     "RetryStateManager",
     "RetryWithBackoffPluginCore",
+    "__version__",
 ]
+
+# Not picked up by pyo3_stub_gen (module-level `m.add(...)` attrs aren't
+# auto-generated) -- declared by hand. Kept in sync manually with the
+# `m.add("__version__", env!("CARGO_PKG_VERSION"))` call in src/lib.rs.
+__version__: builtins.str
 
 @typing.final
 class RetryStateManager:

--- a/plugins/rust/python-package/retry_with_backoff/src/lib.rs
+++ b/plugins/rust/python-package/retry_with_backoff/src/lib.rs
@@ -174,6 +174,10 @@ impl RetryStateManager {
 #[pymodule]
 fn retry_with_backoff_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init();
+    // Single source of truth for the Rust core version: read from Cargo.toml at
+    // compile time so the wrapper's init log can't drift from the crate version
+    // again (it previously hard-coded a version string that went stale).
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<RetryStateManager>()?;
     m.add_class::<plugin::RetryWithBackoffPluginCore>()?;
     Ok(())

--- a/plugins/rust/python-package/retry_with_backoff/src/plugin.rs
+++ b/plugins/rust/python-package/retry_with_backoff/src/plugin.rs
@@ -156,6 +156,27 @@ impl RetryWithBackoffPluginCore {
     }
 }
 
+/// Read `obj[key]` through the Python mapping protocol (`PyObject_GetItem`,
+/// i.e. `__getitem__`), returning `None` for a missing key or any
+/// non-subscriptable/error case. Never raises.
+///
+/// Unlike [`pyo3::types::PyDict::get_item`], which reads the C-level dict
+/// storage directly, this respects `dict` subclasses that keep their data in a
+/// Python-level overlay rather than the C-level storage. The gateway wraps tool
+/// results in exactly such a subclass (the framework's `CopyOnWriteDict`, whose
+/// C-level storage is empty), so `PyDict::get_item` silently misses every key —
+/// a failing tool result then looks like a success and no retry is signalled.
+fn mapping_get<'py>(obj: &Bound<'py, PyAny>, key: &str) -> Option<Bound<'py, PyAny>> {
+    obj.get_item(key).ok()
+}
+
+/// True when `obj[key]` exists and extracts to `true`. Never raises.
+fn mapping_get_bool(obj: &Bound<'_, PyAny>, key: &str) -> bool {
+    mapping_get(obj, key)
+        .and_then(|v| v.extract::<bool>().ok())
+        .unwrap_or(false)
+}
+
 impl RetryWithBackoffPluginCore {
     fn is_failure(
         &self,
@@ -163,19 +184,16 @@ impl RetryWithBackoffPluginCore {
         result: &Bound<'_, PyAny>,
         config: &RetryConfig,
     ) -> PyResult<bool> {
-        // Check if result is a dict
-        let Ok(result_dict) = result.cast::<PyDict>() else {
-            return Ok(false);
-        };
+        // Read every key through the Python mapping protocol (see `mapping_get`):
+        // the gateway wraps tool results in dict subclasses (e.g. CopyOnWriteDict)
+        // whose data lives in a Python-level overlay, so the C-level
+        // `PyDict::get_item` would observe an empty dict and miss `isError`.
 
-        // Check isError flag
-        if let Some(is_error) = result_dict.get_item("isError")?
-            && is_error.extract::<bool>().unwrap_or(false)
-        {
-            // Check structured content for status_code
-            if let Some(structured) = result_dict.get_item("structuredContent")?
-                && let Ok(structured_dict) = structured.cast::<PyDict>()
-                && let Some(status) = structured_dict.get_item("status_code")?
+        // Top-level isError flag
+        if mapping_get_bool(result, "isError") {
+            // status_code (when present) lives under structuredContent
+            if let Some(structured) = mapping_get(result, "structuredContent")
+                && let Some(status) = mapping_get(&structured, "status_code")
                 && let Ok(status_code) = status.extract::<i32>()
             {
                 return Ok(config.retry_on_status.contains(&status_code));
@@ -183,21 +201,15 @@ impl RetryWithBackoffPluginCore {
             return Ok(true);
         }
 
-        // Check structuredContent; track presence to gate text content check
-        // Treat `"structuredContent": None` as absent (matches original Python semantics)
-        let has_structured_content = result_dict
-            .get_item("structuredContent")?
-            .map(|v| !v.is_none())
-            .unwrap_or(false);
-        if let Some(structured) = result_dict.get_item("structuredContent")?
-            && let Ok(structured_dict) = structured.cast::<PyDict>()
-        {
-            if let Some(is_error) = structured_dict.get_item("isError")?
-                && is_error.extract::<bool>().unwrap_or(false)
-            {
+        // Check structuredContent; track presence to gate text content check.
+        // Treat `"structuredContent": None` as absent (matches original Python semantics).
+        let structured = mapping_get(result, "structuredContent").filter(|v| !v.is_none());
+        let has_structured_content = structured.is_some();
+        if let Some(ref structured_dict) = structured {
+            if mapping_get_bool(structured_dict, "isError") {
                 return Ok(true);
             }
-            if let Some(status) = structured_dict.get_item("status_code")?
+            if let Some(status) = mapping_get(structured_dict, "status_code")
                 && let Ok(status_code) = status.extract::<i32>()
                 && config.retry_on_status.contains(&status_code)
             {
@@ -208,36 +220,33 @@ impl RetryWithBackoffPluginCore {
         // Check text content only when enabled and structuredContent is absent
         if config.check_text_content
             && !has_structured_content
-            && let Some(content) = result_dict.get_item("content")?
+            && let Some(content) = mapping_get(result, "content")
             && let Ok(content_list) = content.cast::<PyList>()
         {
             for item in content_list.iter() {
-                if let Ok(item_dict) = item.cast::<PyDict>() {
-                    // Only process items explicitly marked as type "text"
-                    let is_text = item_dict
-                        .get_item("type")?
-                        .and_then(|v| v.extract::<String>().ok())
-                        .as_deref()
-                        == Some("text");
-                    if !is_text {
-                        continue;
+                // Only process items explicitly marked as type "text"
+                let is_text = mapping_get(&item, "type")
+                    .and_then(|v| v.extract::<String>().ok())
+                    .as_deref()
+                    == Some("text");
+                if !is_text {
+                    continue;
+                }
+                // Try to parse text as JSON
+                if let Some(text) = mapping_get(&item, "text")
+                    && let Ok(text_str) = text.extract::<String>()
+                    && let Ok(parsed) = serde_json::from_str::<Value>(&text_str)
+                    && let Some(obj) = parsed.as_object()
+                {
+                    // Check isError in parsed JSON
+                    if obj.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+                        return Ok(true);
                     }
-                    // Try to parse text as JSON
-                    if let Some(text) = item_dict.get_item("text")?
-                        && let Ok(text_str) = text.extract::<String>()
-                        && let Ok(parsed) = serde_json::from_str::<Value>(&text_str)
-                        && let Some(obj) = parsed.as_object()
+                    // Check status_code in parsed JSON
+                    if let Some(status) = obj.get("status_code").and_then(|v| v.as_i64())
+                        && config.retry_on_status.contains(&(status as i32))
                     {
-                        // Check isError in parsed JSON
-                        if obj.get("isError").and_then(|v| v.as_bool()) == Some(true) {
-                            return Ok(true);
-                        }
-                        // Check status_code in parsed JSON
-                        if let Some(status) = obj.get("status_code").and_then(|v| v.as_i64())
-                            && config.retry_on_status.contains(&(status as i32))
-                        {
-                            return Ok(true);
-                        }
+                        return Ok(true);
                     }
                 }
             }
@@ -904,6 +913,57 @@ class ResourcePostFetchResult:
             assert!(
                 is_fail,
                 "isError:true in JSON text content must trigger failure"
+            );
+        });
+    }
+
+    #[test]
+    fn test_is_failure_reads_dict_subclass_overlay_storage() {
+        // Regression (gateway CopyOnWriteDict): the gateway wraps tool results in
+        // a `dict` subclass that keeps its data in a Python-level overlay, leaving
+        // the C-level dict storage empty. Reading via `PyDict::get_item` (C-level)
+        // misses `isError`, so a failing result looked like a success and no retry
+        // was ever signalled. `is_failure` must read through the mapping protocol.
+        Python::initialize();
+        Python::attach(|py| {
+            setup_cpex_framework(py);
+            let config = RetryConfig {
+                max_retries: 2,
+                backoff_base_ms: 100,
+                max_backoff_ms: 10_000,
+                retry_on_status: vec![500],
+                jitter: false,
+                check_text_content: false,
+                tool_overrides: HashMap::new(),
+            };
+            let core = RetryWithBackoffPluginCore {
+                config: config.clone(),
+                state_manager: Arc::new(Mutex::new(HashMap::new())),
+            };
+            // A `dict` subclass whose data lives in a Python-level overlay while
+            // the C-level dict storage stays empty (mirrors CopyOnWriteDict).
+            let module = PyModule::from_code(
+                py,
+                c_str!(
+                    "class CowDict(dict):\n    def __init__(self, data):\n        super().__init__()\n        self._overlay = dict(data)\n    def __getitem__(self, k):\n        return self._overlay[k]\n    def get(self, k, default=None):\n        return self._overlay.get(k, default)\n    def __contains__(self, k):\n        return k in self._overlay\n"
+                ),
+                c_str!("cow.py"),
+                c_str!("cow"),
+            )
+            .unwrap();
+            let inner = PyDict::new(py);
+            inner.set_item("isError", true).unwrap();
+            inner.set_item("structuredContent", py.None()).unwrap();
+            let cow = module.getattr("CowDict").unwrap().call1((inner,)).unwrap();
+
+            // Sanity: C-level dict storage is empty, so the old PyDict::get_item
+            // path would observe nothing and (wrongly) report no failure.
+            assert_eq!(cow.cast::<PyDict>().unwrap().len(), 0);
+
+            let is_fail = core.is_failure(py, &cow, &config).unwrap();
+            assert!(
+                is_fail,
+                "isError:true stored in a dict-subclass overlay must trigger failure"
             );
         });
     }

--- a/plugins/rust/python-package/retry_with_backoff/src/plugin.rs
+++ b/plugins/rust/python-package/retry_with_backoff/src/plugin.rs
@@ -157,8 +157,7 @@ impl RetryWithBackoffPluginCore {
 }
 
 /// Read `obj[key]` through the Python mapping protocol (`PyObject_GetItem`,
-/// i.e. `__getitem__`), returning `None` for a missing key or any
-/// non-subscriptable/error case. Never raises.
+/// i.e. `__getitem__`).
 ///
 /// Unlike [`pyo3::types::PyDict::get_item`], which reads the C-level dict
 /// storage directly, this respects `dict` subclasses that keep their data in a
@@ -166,15 +165,34 @@ impl RetryWithBackoffPluginCore {
 /// results in exactly such a subclass (the framework's `CopyOnWriteDict`, whose
 /// C-level storage is empty), so `PyDict::get_item` silently misses every key —
 /// a failing tool result then looks like a success and no retry is signalled.
-fn mapping_get<'py>(obj: &Bound<'py, PyAny>, key: &str) -> Option<Bound<'py, PyAny>> {
-    obj.get_item(key).ok()
+///
+/// Returns `Ok(None)` for a genuinely absent key (`KeyError`, matching
+/// `dict.get` semantics) or a non-subscriptable `obj` (`TypeError`). Any other
+/// exception — e.g. a custom `__getitem__`/property that raises on access — is
+/// propagated rather than swallowed, so a broken mapping surfaces as an error
+/// instead of silently masquerading as "not a failure" (no retry).
+fn mapping_get<'py>(obj: &Bound<'py, PyAny>, key: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
+    match obj.get_item(key) {
+        Ok(v) => Ok(Some(v)),
+        Err(e) => {
+            let py = obj.py();
+            if e.is_instance_of::<pyo3::exceptions::PyKeyError>(py)
+                || e.is_instance_of::<pyo3::exceptions::PyTypeError>(py)
+            {
+                Ok(None)
+            } else {
+                Err(e)
+            }
+        }
+    }
 }
 
-/// True when `obj[key]` exists and extracts to `true`. Never raises.
-fn mapping_get_bool(obj: &Bound<'_, PyAny>, key: &str) -> bool {
-    mapping_get(obj, key)
+/// True when `obj[key]` exists and extracts to `true`. Propagates any error
+/// from [`mapping_get`] other than a missing key / non-subscriptable `obj`.
+fn mapping_get_bool(obj: &Bound<'_, PyAny>, key: &str) -> PyResult<bool> {
+    Ok(mapping_get(obj, key)?
         .and_then(|v| v.extract::<bool>().ok())
-        .unwrap_or(false)
+        .unwrap_or(false))
 }
 
 impl RetryWithBackoffPluginCore {
@@ -190,10 +208,10 @@ impl RetryWithBackoffPluginCore {
         // `PyDict::get_item` would observe an empty dict and miss `isError`.
 
         // Top-level isError flag
-        if mapping_get_bool(result, "isError") {
+        if mapping_get_bool(result, "isError")? {
             // status_code (when present) lives under structuredContent
-            if let Some(structured) = mapping_get(result, "structuredContent")
-                && let Some(status) = mapping_get(&structured, "status_code")
+            if let Some(structured) = mapping_get(result, "structuredContent")?
+                && let Some(status) = mapping_get(&structured, "status_code")?
                 && let Ok(status_code) = status.extract::<i32>()
             {
                 return Ok(config.retry_on_status.contains(&status_code));
@@ -203,13 +221,13 @@ impl RetryWithBackoffPluginCore {
 
         // Check structuredContent; track presence to gate text content check.
         // Treat `"structuredContent": None` as absent (matches original Python semantics).
-        let structured = mapping_get(result, "structuredContent").filter(|v| !v.is_none());
+        let structured = mapping_get(result, "structuredContent")?.filter(|v| !v.is_none());
         let has_structured_content = structured.is_some();
         if let Some(ref structured_dict) = structured {
-            if mapping_get_bool(structured_dict, "isError") {
+            if mapping_get_bool(structured_dict, "isError")? {
                 return Ok(true);
             }
-            if let Some(status) = mapping_get(structured_dict, "status_code")
+            if let Some(status) = mapping_get(structured_dict, "status_code")?
                 && let Ok(status_code) = status.extract::<i32>()
                 && config.retry_on_status.contains(&status_code)
             {
@@ -220,12 +238,12 @@ impl RetryWithBackoffPluginCore {
         // Check text content only when enabled and structuredContent is absent
         if config.check_text_content
             && !has_structured_content
-            && let Some(content) = mapping_get(result, "content")
+            && let Some(content) = mapping_get(result, "content")?
             && let Ok(content_list) = content.cast::<PyList>()
         {
             for item in content_list.iter() {
                 // Only process items explicitly marked as type "text"
-                let is_text = mapping_get(&item, "type")
+                let is_text = mapping_get(&item, "type")?
                     .and_then(|v| v.extract::<String>().ok())
                     .as_deref()
                     == Some("text");
@@ -233,7 +251,7 @@ impl RetryWithBackoffPluginCore {
                     continue;
                 }
                 // Try to parse text as JSON
-                if let Some(text) = mapping_get(&item, "text")
+                if let Some(text) = mapping_get(&item, "text")?
                     && let Ok(text_str) = text.extract::<String>()
                     && let Ok(parsed) = serde_json::from_str::<Value>(&text_str)
                     && let Some(obj) = parsed.as_object()
@@ -964,6 +982,51 @@ class ResourcePostFetchResult:
             assert!(
                 is_fail,
                 "isError:true stored in a dict-subclass overlay must trigger failure"
+            );
+        });
+    }
+
+    #[test]
+    fn test_is_failure_propagates_unexpected_getitem_error() {
+        // Regression: `mapping_get` must only swallow KeyError/TypeError (missing
+        // key / non-subscriptable). A `__getitem__` that raises anything else
+        // (a bug, a broken proxy) must surface as an error from `is_failure`
+        // rather than being silently treated as "not a failure" — the latter
+        // would open another silent no-retry path identical in spirit to the
+        // CopyOnWriteDict regression this file fixes.
+        Python::initialize();
+        Python::attach(|py| {
+            setup_cpex_framework(py);
+            let config = RetryConfig {
+                max_retries: 2,
+                backoff_base_ms: 100,
+                max_backoff_ms: 10_000,
+                retry_on_status: vec![500],
+                jitter: false,
+                check_text_content: false,
+                tool_overrides: HashMap::new(),
+            };
+            let core = RetryWithBackoffPluginCore {
+                config: config.clone(),
+                state_manager: Arc::new(Mutex::new(HashMap::new())),
+            };
+            let module = PyModule::from_code(
+                py,
+                c_str!(
+                    "class BrokenDict(dict):\n    def __getitem__(self, k):\n        raise RuntimeError('boom')\n"
+                ),
+                c_str!("broken.py"),
+                c_str!("broken"),
+            )
+            .unwrap();
+            let broken = module.getattr("BrokenDict").unwrap().call0().unwrap();
+
+            let err = core
+                .is_failure(py, &broken, &config)
+                .expect_err("a non-KeyError/TypeError __getitem__ failure must propagate");
+            assert!(
+                err.is_instance_of::<pyo3::exceptions::PyRuntimeError>(py),
+                "expected the original RuntimeError to propagate, got: {err}"
             );
         });
     }


### PR DESCRIPTION
## Related issue

Closes #124

## Problem

`RetryWithBackoffPlugin` (Rust core, `>=0.3.2`) never retries inside the MCP ContextForge gateway — every failing tool result is treated as a success. Root cause: the gateway wraps `tool_post_invoke` results in `cpex.framework.memory.CopyOnWriteDict`, a `dict` subclass that keeps its data in a Python-level overlay and leaves the C-level dict storage empty. `is_failure` read keys with `PyDict::get_item` (C-level `PyDict_GetItem`), so it observed an empty dict, never found `isError`, and returned `retry_delay_ms=0`. The gateway retries only when `retry_delay_ms > 0`, so it never retried.

Regressed in the `0.3.2` Python→Rust rewrite; pure-Python `0.3.1` used `result.get(...)` (the overridden `__getitem__`) and worked. Full analysis and reproduction in #136.

## Fix

- Read every result key through the Python mapping protocol (`PyObject_GetItem` → `__getitem__`) via new `mapping_get` / `mapping_get_bool` helpers, instead of `PyDict::get_item`. Dict subclasses with overlay storage now work; plain-dict behaviour is unchanged.
- Regression test `test_is_failure_reads_dict_subclass_overlay_storage`: feeds `is_failure` a dict subclass whose C-level storage is empty and asserts the failure is still detected (asserts C-level `len == 0` first, so it would fail against the old code).
- Bump `0.3.6` → `0.3.7`; fix the stale `v0.3.2` init log string.

## Verification

- `cargo test --lib` — 56/56 pass (incl. the new regression test).
- `cargo fmt --check`, `cargo clippy --all-targets` — clean.
- Rebuilt the wheel and ran the gateway E2E (`tests/live_gateway/plugins/test_retry_with_backoff_e2e.py`) end-to-end against the real fast-time-server image: **both `static` and `binding` legs pass** (they fail against the current `0.3.6`).

## Downstream

`IBM/mcp-context-forge#5611` will pin `cpex-retry-with-backoff>=0.3.7` once this ships to PyPI.


