### PR TITLE
fix(secrets_detection): detect quoted AWS secret keys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T09:20:59Z",
+  "generated_at": "2026-07-15T10:10:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -170,7 +170,7 @@
         "hashed_secret": "078553dc10635837abb80f404302c70cba91b879",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 238,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -178,7 +178,7 @@
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 238,
         "type": "GitHub Token",
         "verified_result": null
       },
@@ -186,7 +186,7 @@
         "hashed_secret": "97d99a51e5ac827bb36fe6273facfda35245917a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 242,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -194,7 +194,7 @@
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 260,
         "type": "Private Key",
         "verified_result": null
       },
@@ -202,7 +202,7 @@
         "hashed_secret": "b1775a785f09a6ebaf2dc33d6eaeb98974d9cdb8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 268,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -210,7 +210,7 @@
         "hashed_secret": "eae9124e42e2ef05ba727bd1a1c0c6fa61a05b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +218,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 240,
+        "line_number": 313,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -226,7 +226,7 @@
         "hashed_secret": "9d7235fe33b6612ed7ebca4b63afd00d4adf5d66",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 367,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -234,7 +234,7 @@
         "hashed_secret": "356bcfac838d811d3c26b4c46025dc87cff866c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 325,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -334,7 +334,7 @@
         "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 158,
+        "line_number": 183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 546,
+        "line_number": 571,
         "type": "AWS Access Key",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-02T09:07:21Z",
+  "generated_at": "2026-07-15T09:20:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -80,11 +80,11 @@
     "docs/superpowers/plans/2026-06-30-otel-plugin-boundary-metadata.md": [
       {
         "hashed_secret": "fc2398a73dd54d6237c4fdb58fd7d75347cf5af3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 417,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/rust/python-package/encoded_exfil_detection/src/lib.rs": [
@@ -170,7 +170,7 @@
         "hashed_secret": "078553dc10635837abb80f404302c70cba91b879",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 165,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -178,7 +178,7 @@
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 165,
         "type": "GitHub Token",
         "verified_result": null
       },
@@ -186,7 +186,7 @@
         "hashed_secret": "97d99a51e5ac827bb36fe6273facfda35245917a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 169,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -194,7 +194,7 @@
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 187,
         "type": "Private Key",
         "verified_result": null
       },
@@ -202,7 +202,7 @@
         "hashed_secret": "b1775a785f09a6ebaf2dc33d6eaeb98974d9cdb8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 175,
+        "line_number": 195,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -210,7 +210,7 @@
         "hashed_secret": "eae9124e42e2ef05ba727bd1a1c0c6fa61a05b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +218,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 220,
+        "line_number": 240,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -226,7 +226,7 @@
         "hashed_secret": "9d7235fe33b6612ed7ebca4b63afd00d4adf5d66",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 274,
+        "line_number": 294,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -234,7 +234,7 @@
         "hashed_secret": "356bcfac838d811d3c26b4c46025dc87cff866c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 325,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -302,11 +302,11 @@
     "plugins/tests/pii_filter/test_integration.py": [
       {
         "hashed_secret": "fc2398a73dd54d6237c4fdb58fd7d75347cf5af3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 529,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "plugins/tests/secrets_detection/test_hook_dispatch.py": [
@@ -334,7 +334,7 @@
         "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 158,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 384,
+        "line_number": 546,
         "type": "AWS Access Key",
         "verified_result": null
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets_detection"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/plugins/rust/python-package/secrets_detection/Cargo.toml
+++ b/plugins/rust/python-package/secrets_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secrets_detection"
-version = "0.3.7"
+version = "0.3.8"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/secrets_detection/README.md
+++ b/plugins/rust/python-package/secrets_detection/README.md
@@ -90,6 +90,7 @@ config:
 ## Behavior Notes
 
 - Redaction preserves payload shape where possible instead of flattening everything to plain dicts.
+- `aws_secret_access_key` recognizes `=` and `:` assignments with optional single or double quotes around the value.
 - `base64_24` uses capture-group redaction so leading non-base64 boundary characters are preserved.
 - Broad detectors remain opt-in to reduce noisy matches on ordinary identifiers.
 - Binary resource bodies are not scanned; `resource_post_fetch` only scans text content exposed as `payload.content.text`.

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect likely credentials and secrets in prompt input, tool output, and resource content"
 author: "ContextForge Contributors"
-version: "0.3.7"
+version: "0.3.8"
 kind: "cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -13,7 +13,7 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     );
     patterns.insert(
         "aws_secret_access_key",
-        Regex::new(r"(?i)aws.{0,20}(?:secret|access).{0,20}=\s*([A-Za-z0-9/+=]{40})")
+        Regex::new(r#"(?i)aws.{0,20}(?:secret|access).{0,20}=\s*["']?([A-Za-z0-9/+=]{40})["']?"#)
             .expect("valid aws_secret_access_key regex"),
     );
     patterns.insert(

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -13,8 +13,10 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     );
     patterns.insert(
         "aws_secret_access_key",
-        Regex::new(r#"(?i)aws.{0,20}(?:secret|access).{0,20}=\s*["']?([A-Za-z0-9/+=]{40})["']?"#)
-            .expect("valid aws_secret_access_key regex"),
+        Regex::new(
+            r#"(?i)aws.{0,20}(?:secret|access).{0,20}[:=]\s*["']?([A-Za-z0-9/+=]{40})["']?"#,
+        )
+        .expect("valid aws_secret_access_key regex"),
     );
     patterns.insert(
         "google_api_key",

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -60,6 +60,8 @@ fn scan_value(value: &Value, config: &SecretsDetectionConfig) -> (usize, Value, 
 mod tests {
     use super::*;
 
+    const SECRET_FIXTURE: &str = "FAKESecretAccessKeyForTestingEXAMPLE0000"; // pragma: allowlist secret
+
     #[test]
     fn detects_aws_secret_access_key() {
         let config = SecretsDetectionConfig::default();
@@ -75,22 +77,93 @@ mod tests {
     }
 
     #[test]
-    fn detects_quoted_aws_secret_access_keys() {
+    fn detects_aws_secret_access_key_assignment_formats() {
         let config = SecretsDetectionConfig {
             redact: true,
             redaction_text: "[REDACTED]".to_string(),
             ..Default::default()
         };
 
-        for text in [
-            "aws_secret_access_key = \"FAKESecretAccessKeyForTestingEXAMPLE0000\"", // pragma: allowlist secret
-            "aws_secret_access_key = 'FAKESecretAccessKeyForTestingEXAMPLE0000'", // pragma: allowlist secret
-        ] {
-            let (findings, redacted) = detect_and_redact(text, &config);
+        let cases = [
+            (
+                "equals-unquoted",
+                format!("AWS_SECRET_ACCESS_KEY={SECRET_FIXTURE}"), // pragma: allowlist secret
+            ),
+            (
+                "equals-double-quoted",
+                format!("aws_secret_access_key = \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+            (
+                "equals-single-quoted",
+                format!("aws_secret_access_key = '{SECRET_FIXTURE}'"), // pragma: allowlist secret
+            ),
+            (
+                "yaml-unquoted",
+                format!("aws_secret_access_key: {SECRET_FIXTURE}"), // pragma: allowlist secret
+            ),
+            (
+                "yaml-double-quoted",
+                format!("aws_secret_access_key: \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+            (
+                "yaml-single-quoted",
+                format!("aws_secret_access_key: '{SECRET_FIXTURE}'"), // pragma: allowlist secret
+            ),
+            (
+                "json-spaced",
+                format!(r#""aws_secret_access_key": "{SECRET_FIXTURE}""#), // pragma: allowlist secret
+            ),
+            (
+                "json-compact",
+                format!(r#""aws_secret_access_key":"{SECRET_FIXTURE}""#), // pragma: allowlist secret
+            ),
+            (
+                "mixed-case",
+                format!("AwsSecretAccessKey: \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+        ];
 
-            assert_eq!(findings.len(), 1, "{text}: {findings:?}");
-            assert_eq!(findings[0].pii_type, "aws_secret_access_key");
-            assert_eq!(redacted, config.redaction_text);
+        for (name, text) in cases {
+            let (findings, redacted) = detect_and_redact(&text, &config);
+
+            assert_eq!(findings.len(), 1, "{name}: {findings:?}");
+            assert_eq!(findings[0].pii_type, "aws_secret_access_key", "{name}");
+            assert!(!redacted.contains(SECRET_FIXTURE), "{name}: {redacted}");
+            assert!(
+                redacted.contains(&config.redaction_text),
+                "{name}: {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_non_assignment_aws_secret_access_key_text() {
+        let config = SecretsDetectionConfig::default();
+        let short_value = "A".repeat(39);
+        let cases = [
+            (
+                "missing-separator",
+                format!("aws_secret_access_key \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+            (
+                "unsupported-separator",
+                format!("aws_secret_access_key -> \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+            (
+                "different-aws-field",
+                format!("aws_session_token: \"{SECRET_FIXTURE}\""), // pragma: allowlist secret
+            ),
+            (
+                "short-value",
+                format!("aws_secret_access_key: \"{short_value}\""), // pragma: allowlist secret
+            ),
+        ];
+
+        for (name, text) in cases {
+            let (findings, redacted) = detect_and_redact(&text, &config);
+
+            assert!(findings.is_empty(), "{name}: {findings:?}");
+            assert_eq!(redacted, text, "{name}");
         }
     }
 

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -75,6 +75,26 @@ mod tests {
     }
 
     #[test]
+    fn detects_quoted_aws_secret_access_keys() {
+        let config = SecretsDetectionConfig {
+            redact: true,
+            redaction_text: "[REDACTED]".to_string(),
+            ..Default::default()
+        };
+
+        for text in [
+            "aws_secret_access_key = \"FAKESecretAccessKeyForTestingEXAMPLE0000\"", // pragma: allowlist secret
+            "aws_secret_access_key = 'FAKESecretAccessKeyForTestingEXAMPLE0000'", // pragma: allowlist secret
+        ] {
+            let (findings, redacted) = detect_and_redact(text, &config);
+
+            assert_eq!(findings.len(), 1, "{text}: {findings:?}");
+            assert_eq!(findings[0].pii_type, "aws_secret_access_key");
+            assert_eq!(redacted, config.redaction_text);
+        }
+    }
+
+    #[test]
     fn detects_slack_token() {
         let config = SecretsDetectionConfig::default();
         let (findings, _) = detect_and_redact(

--- a/plugins/tests/secrets_detection/test_plugin_hook_results.py
+++ b/plugins/tests/secrets_detection/test_plugin_hook_results.py
@@ -39,6 +39,56 @@ class TestPluginHookResults:
         # No extensions/trace_id passed => gated, no metadata write at all.
         assert result.metadata == {}
 
+    async def test_tool_post_invoke_redacts_quoted_aws_secret_access_key(self, plugin):
+        payload = ToolPostInvokePayload(
+            name="get_file_contents",
+            result={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            'aws_secret_access_key = '  # pragma: allowlist secret
+                            '"FAKESecretAccessKeyForTestingEXAMPLE0000"'
+                        ),
+                    }
+                ],
+                "isError": False,
+            },
+        )
+
+        result = await plugin.tool_post_invoke(payload, make_context())
+
+        assert result.continue_processing is True
+        assert result.violation is None
+        assert result.modified_payload is not None
+        assert result.modified_payload.result["content"][0]["text"] == "[REDACTED]"
+
+    async def test_tool_post_invoke_blocks_quoted_aws_secret_access_key(self):
+        plugin = SecretsDetectionPlugin(
+            make_config(block_on_detection=True, redact=False)
+        )
+        payload = ToolPostInvokePayload(
+            name="get_file_contents",
+            result={
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            'aws_secret_access_key = '  # pragma: allowlist secret
+                            '"FAKESecretAccessKeyForTestingEXAMPLE0000"'
+                        ),
+                    }
+                ],
+                "isError": False,
+            },
+        )
+
+        result = await plugin.tool_post_invoke(payload, make_context())
+
+        assert result.continue_processing is False
+        assert result.violation is not None
+        assert result.violation.code == "SECRETS_DETECTED"
+
     async def test_tool_post_invoke_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
         payload = ToolPostInvokePayload(
             name="writer",

--- a/plugins/tests/secrets_detection/test_plugin_hook_results.py
+++ b/plugins/tests/secrets_detection/test_plugin_hook_results.py
@@ -6,6 +6,29 @@ from cpex.framework.memory import wrap_payload_for_isolation
 
 from secrets_detection.helpers import *  # noqa: F403,F405
 
+AWS_SECRET_ASSIGNMENTS = [
+    pytest.param(
+        'aws_secret_access_key = "FAKESecretAccessKeyForTestingEXAMPLE0000"',  # pragma: allowlist secret
+        id="equals-double-quoted",
+    ),
+    pytest.param(
+        "aws_secret_access_key = 'FAKESecretAccessKeyForTestingEXAMPLE0000'",  # pragma: allowlist secret
+        id="equals-single-quoted",
+    ),
+    pytest.param(
+        'aws_secret_access_key: "FAKESecretAccessKeyForTestingEXAMPLE0000"',  # pragma: allowlist secret
+        id="yaml-double-quoted",
+    ),
+    pytest.param(
+        "aws_secret_access_key: FAKESecretAccessKeyForTestingEXAMPLE0000",  # pragma: allowlist secret
+        id="yaml-unquoted",
+    ),
+    pytest.param(
+        '"aws_secret_access_key": "FAKESecretAccessKeyForTestingEXAMPLE0000"',  # pragma: allowlist secret
+        id="json-double-quoted",
+    ),
+]
+
 
 @pytest.mark.asyncio
 class TestPluginHookResults:
@@ -39,17 +62,17 @@ class TestPluginHookResults:
         # No extensions/trace_id passed => gated, no metadata write at all.
         assert result.metadata == {}
 
-    async def test_tool_post_invoke_redacts_quoted_aws_secret_access_key(self, plugin):
+    @pytest.mark.parametrize("assignment", AWS_SECRET_ASSIGNMENTS)
+    async def test_tool_post_invoke_redacts_aws_secret_assignment(
+        self, plugin, assignment
+    ):
         payload = ToolPostInvokePayload(
             name="get_file_contents",
             result={
                 "content": [
                     {
                         "type": "text",
-                        "text": (
-                            'aws_secret_access_key = '  # pragma: allowlist secret
-                            '"FAKESecretAccessKeyForTestingEXAMPLE0000"'
-                        ),
+                        "text": assignment,
                     }
                 ],
                 "isError": False,
@@ -61,9 +84,13 @@ class TestPluginHookResults:
         assert result.continue_processing is True
         assert result.violation is None
         assert result.modified_payload is not None
-        assert result.modified_payload.result["content"][0]["text"] == "[REDACTED]"
+        redacted = result.modified_payload.result["content"][0]["text"]
+        assert "[REDACTED]" in redacted
+        assert redacted != assignment
+        assert payload.result["content"][0]["text"] == assignment
 
-    async def test_tool_post_invoke_blocks_quoted_aws_secret_access_key(self):
+    @pytest.mark.parametrize("assignment", AWS_SECRET_ASSIGNMENTS)
+    async def test_tool_post_invoke_blocks_aws_secret_assignment(self, assignment):
         plugin = SecretsDetectionPlugin(
             make_config(block_on_detection=True, redact=False)
         )
@@ -73,10 +100,7 @@ class TestPluginHookResults:
                 "content": [
                     {
                         "type": "text",
-                        "text": (
-                            'aws_secret_access_key = '  # pragma: allowlist secret
-                            '"FAKESecretAccessKeyForTestingEXAMPLE0000"'
-                        ),
+                        "text": assignment,
                     }
                 ],
                 "isError": False,
@@ -88,6 +112,7 @@ class TestPluginHookResults:
         assert result.continue_processing is False
         assert result.violation is not None
         assert result.violation.code == "SECRETS_DETECTED"
+        assert result.modified_payload == payload
 
     async def test_tool_post_invoke_redaction_survives_cpex_policy_with_isolated_payload(self, plugin):
         payload = ToolPostInvokePayload(


### PR DESCRIPTION
## Summary

- accept optional single or double quotes around AWS Secret Access Key values
- add Rust scanner coverage for both quote styles
- add tool post-invoke regression tests for Redact and Block behavior
- bump the secrets_detection plugin version to 0.3.8

## Root cause

The `aws_secret_access_key` regex required the 40-character value to begin immediately after whitespace following `=`. Common quoted assignments therefore produced zero findings, so neither redaction nor blocking was applied.

## Impact

Tool responses containing quoted AWS Secret Access Key assignments are now detected and follow the configured Redact or Block enforcement action.

## Validation

- `make ci` in `plugins/rust/python-package/secrets_detection`
  - 80 Rust tests passed
  - 100 Python integration tests passed
  - rustfmt, Clippy, release wheel build, and benchmark compilation passed
- repository pre-commit hooks passed, including secret detection

## Tracking

- https://github.ibm.com/WatsonOrchestrate/wo-tracker/issues/78411
