### PR TITLE
fix(secrets_detection): preserve secret field names during redaction

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(^\\.secrets\\.baseline$|package-lock\\.json$|Cargo\\.lock$|uv\\.lock$|go\\.sum$|poetry\\.lock$|Pipfile\\.lock$)|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T10:10:56Z",
+  "generated_at": "2026-07-21T09:27:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -167,50 +167,18 @@
     ],
     "plugins/rust/python-package/secrets_detection/src/scanner.rs": [
       {
-        "hashed_secret": "078553dc10635837abb80f404302c70cba91b879",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "GitHub Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "97d99a51e5ac827bb36fe6273facfda35245917a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 242,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 260,
+        "line_number": 270,
         "type": "Private Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b1775a785f09a6ebaf2dc33d6eaeb98974d9cdb8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 268,
-        "type": "Hex High Entropy String",
         "verified_result": null
       },
       {
         "hashed_secret": "eae9124e42e2ef05ba727bd1a1c0c6fa61a05b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 307,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -218,7 +186,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 313,
+        "line_number": 330,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -226,7 +194,7 @@
         "hashed_secret": "9d7235fe33b6612ed7ebca4b63afd00d4adf5d66",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 367,
+        "line_number": 384,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -234,7 +202,7 @@
         "hashed_secret": "356bcfac838d811d3c26b4c46025dc87cff866c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -244,7 +212,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1227,
+        "line_number": 1548,
         "type": "AWS Access Key",
         "verified_result": null
       }
@@ -334,7 +302,7 @@
         "hashed_secret": "462854f9c73adf5f5d5c411adb6b929ecc19693a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 183,
+        "line_number": 184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +310,7 @@
         "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 572,
         "type": "AWS Access Key",
         "verified_result": null
       }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrets_detection"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "cpex_framework_bridge",
  "criterion",

--- a/plugins/rust/python-package/secrets_detection/Cargo.toml
+++ b/plugins/rust/python-package/secrets_detection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secrets_detection"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/plugins/rust/python-package/secrets_detection/README.md
+++ b/plugins/rust/python-package/secrets_detection/README.md
@@ -132,7 +132,7 @@ config:
 
 - Redaction preserves payload shape where possible instead of flattening everything to plain dicts.
 - `aws_secret_access_key` recognizes `=` and `:` assignments with optional single or double quotes around the value.
-- `base64_24` uses capture-group redaction so leading non-base64 boundary characters are preserved.
+- `aws_secret_access_key`, `generic_api_key_assignment`, and `base64_24` use capture-group redaction so only the detected secret span is replaced; assignment labels, separators, quotes, and leading non-base64 boundary characters are preserved.
 - Broad detectors remain opt-in to reduce noisy matches on ordinary identifiers.
 - Binary resource bodies are not scanned; `resource_post_fetch` only scans text content exposed as `payload.content.text`.
 - The plugin does not decode archives, compressed data, or arbitrary encoded blobs before scanning.

--- a/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
+++ b/plugins/rust/python-package/secrets_detection/cpex_secrets_detection/plugin-manifest.yaml
@@ -1,6 +1,6 @@
 description: "Detect likely credentials and secrets in prompt input, tool output, and resource content"
 author: "ContextForge Contributors"
-version: "0.3.9"
+version: "0.3.10"
 kind: "cpex_secrets_detection.secrets_detection.SecretsDetectionPlugin"
 available_hooks:
   - "prompt_pre_fetch"

--- a/plugins/rust/python-package/secrets_detection/src/patterns.rs
+++ b/plugins/rust/python-package/secrets_detection/src/patterns.rs
@@ -35,7 +35,7 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     patterns.insert(
         "generic_api_key_assignment",
         Regex::new(
-            r#"(?ix)\b(?:(?:x[-_])?api[-_]?key|apikey|api[_-]?token|access[_-]?token|bearer[_-]?token|auth[_-]?token)\b\s*[:=]\s*['"]?[A-Za-z0-9_\-]{20,}['"]?"#,
+            r#"(?ix)\b(?:(?:x[-_])?api[-_]?key|apikey|api[_-]?token|access[_-]?token|bearer[_-]?token|auth[_-]?token)\b\s*[:=]\s*['"]?([A-Za-z0-9_\-]{20,})['"]?"#,
         )
         .expect("valid generic_api_key_assignment regex"),
     );
@@ -72,8 +72,13 @@ pub static PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new(|| {
     patterns
 });
 
-pub static CAPTURE_PATTERNS: LazyLock<HashSet<&'static str>> =
-    LazyLock::new(|| HashSet::from(["base64_24"]));
+pub static CAPTURE_PATTERNS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    HashSet::from([
+        "aws_secret_access_key",
+        "generic_api_key_assignment",
+        "base64_24",
+    ])
+});
 
 #[cfg(test)]
 mod tests {

--- a/plugins/rust/python-package/secrets_detection/src/scanner.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner.rs
@@ -128,10 +128,10 @@ mod tests {
 
             assert_eq!(findings.len(), 1, "{name}: {findings:?}");
             assert_eq!(findings[0].pii_type, "aws_secret_access_key", "{name}");
-            assert!(!redacted.contains(SECRET_FIXTURE), "{name}: {redacted}");
-            assert!(
-                redacted.contains(&config.redaction_text),
-                "{name}: {redacted}"
+            assert_eq!(
+                redacted,
+                text.replace(SECRET_FIXTURE, &config.redaction_text),
+                "{name}"
             );
         }
     }
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn redacts_each_supported_secret_as_one_replacement_with_all_patterns_enabled() {
+    fn redacts_only_secret_value_for_each_supported_detector_with_all_patterns_enabled() {
         let config = SecretsDetectionConfig {
             enabled: crate::patterns::PATTERNS
                 .keys()
@@ -223,56 +223,73 @@ mod tests {
             ..Default::default()
         };
 
-        for (name, secret) in [
-            ("aws_access_key_id", "AKIAFAKE12345EXAMPLE".to_string()),
+        for (name, text, expected) in [
+            (
+                "aws_access_key_id",
+                "aws_access_key_id=AKIAFAKE12345EXAMPLE".to_string(),
+                "aws_access_key_id=[TESTING-REDACTED]".to_string(),
+            ),
             (
                 "aws_secret_access_key",
-                "AWS_SECRET_ACCESS_KEY=FAKESecretAccessKeyForTestingEXAMPLE0000".to_string(),
+                "aws_secret_access_key=\"FAKESecretAccessKeyForTestingEXAMPLE0000\"".to_string(),
+                "aws_secret_access_key=\"[TESTING-REDACTED]\"".to_string(),
             ),
             (
                 "google_api_key",
-                "AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+                "google_api_key=AIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+                "google_api_key=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "github_token",
-                "ghp_abcdefghijklmnopqrstuvwxyz0123456789".to_string(),
+                "github_token=ghp_abcdefghijklmnopqrstuvwxyz0123456789".to_string(), // pragma: allowlist secret
+                "github_token=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "stripe_secret_key",
-                "sk_test_abcdefghijklmnopqrstuvwxyz".to_string(),
+                "stripe_secret_key=sk_test_abcdefghijklmnopqrstuvwxyz".to_string(),
+                "stripe_secret_key=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "generic_api_key_assignment",
-                "api_key=test12345678901234567890".to_string(),
+                "api_key=\"test12345678901234567890\"".to_string(),
+                "api_key=\"[TESTING-REDACTED]\"".to_string(),
             ),
             (
                 "slack_token",
                 [
-                    "xoxb",
+                    "slack_token=xoxb",
                     "123456789012",
                     "123456789012",
                     "abcdefghijklmnopqrstuvwx",
                 ]
                 .join("-"),
+                "slack_token=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "private_key_block",
-                "-----BEGIN RSA PRIVATE KEY-----".to_string(),
+                "private_key_block=-----BEGIN RSA PRIVATE KEY-----".to_string(),
+                "private_key_block=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "jwt_like",
-                "eyJaaaaaaaaaaa.eyJbbbbbbbbbbb.cccccccccccccc".to_string(),
+                "jwt_like=eyJaaaaaaaaaaa.eyJbbbbbbbbbbb.cccccccccccccc".to_string(),
+                "jwt_like=[TESTING-REDACTED]".to_string(),
             ),
             (
                 "hex_secret_32",
-                "0123456789abcdef0123456789abcdef".to_string(),
+                "hex_secret_32=0123456789abcdef0123456789abcdef".to_string(),
+                "hex_secret_32=[TESTING-REDACTED]".to_string(),
             ),
-            ("base64_24", "QUJDREVGR0hJSktMTU5PUFFSU1RVVldY".to_string()),
+            (
+                "base64_24",
+                "base64_24=QUJDREVGR0hJSktMTU5PUFFSU1RVVldY".to_string(), // pragma: allowlist secret
+                "base64_24=[TESTING-REDACTED]".to_string(),
+            ),
         ] {
-            let (findings, redacted) = detect_and_redact(&secret, &config);
+            let (findings, redacted) = detect_and_redact(&text, &config);
             assert_eq!(findings.len(), 1, "{name}: {findings:?}");
             assert_eq!(findings[0].pii_type, name, "{name}: {findings:?}");
-            assert_eq!(redacted, config.redaction_text, "{name}");
+            assert_eq!(redacted, expected, "{name}");
         }
     }
 

--- a/plugins/rust/python-package/secrets_detection/src/scanner/cycle_rewrite.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/cycle_rewrite.rs
@@ -235,7 +235,7 @@ class CleanObject:
             );
             assert_eq!(
                 redacted_tuple.get_item(1)?.extract::<String>()?,
-                "[REDACTED]"
+                "AWS_SECRET_ACCESS_KEY=[REDACTED]"
             );
 
             Ok(())

--- a/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/python_scan/tests.rs
@@ -517,8 +517,8 @@ class LeakModel:
         let internal = redacted.getattr("internal")?.extract::<String>()?;
         let external = redacted.getattr("external")?.extract::<String>()?;
 
-        assert_eq!(internal, config.redaction_text);
-        assert_eq!(external, config.redaction_text);
+        assert_eq!(internal, "AWS_SECRET_ACCESS_KEY=[REDACTED]");
+        assert_eq!(external, "AWS_SECRET_ACCESS_KEY=[REDACTED]");
         assert_ne!(
             internal,
             "AWS_SECRET_ACCESS_KEY=FAKESecretAccessKeyForTestingEXAMPLE0000"
@@ -847,7 +847,11 @@ class Model:
             .iter()
             .filter_map(|value| value.extract::<String>().ok())
             .collect();
-        assert!(values.iter().any(|value| value == "[REDACTED]"));
+        assert!(
+            values
+                .iter()
+                .any(|value| value == "AWS_SECRET_ACCESS_KEY=[REDACTED]")
+        );
 
         Ok(())
     })

--- a/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
+++ b/plugins/rust/python-package/secrets_detection/src/scanner/text_scan.rs
@@ -26,13 +26,15 @@ pub fn detect_and_redact(text: &str, config: &SecretsDetectionConfig) -> (Vec<Fi
         }
 
         if CAPTURE_PATTERNS.contains(name) {
-            // Capturing patterns exclude boundary chars from findings. Rust
-            // regex has no lookbehind, so group 1 is the actual secret span.
+            // Capturing patterns exclude labels, quotes, or boundary chars
+            // from findings. Group 1 is always the actual secret span.
             for captures in pattern.captures_iter(text) {
                 let Some(matched) = captures.get(1) else {
                     continue;
                 };
-                if is_base64_boundary_char(text[matched.end()..].chars().next()) {
+                if *name == "base64_24"
+                    && is_base64_boundary_char(text[matched.end()..].chars().next())
+                {
                     continue;
                 }
                 candidates.push(MatchCandidate {

--- a/plugins/tests/secrets_detection/test_plugin_hook_results.py
+++ b/plugins/tests/secrets_detection/test_plugin_hook_results.py
@@ -6,6 +6,8 @@ from cpex.framework.memory import wrap_payload_for_isolation
 
 from secrets_detection.helpers import *  # noqa: F403,F405
 
+AWS_SECRET_VALUE = "FAKESecretAccessKeyForTestingEXAMPLE0000"  # pragma: allowlist secret
+
 AWS_SECRET_ASSIGNMENTS = [
     pytest.param(
         'aws_secret_access_key = "FAKESecretAccessKeyForTestingEXAMPLE0000"',  # pragma: allowlist secret
@@ -85,8 +87,7 @@ class TestPluginHookResults:
         assert result.violation is None
         assert result.modified_payload is not None
         redacted = result.modified_payload.result["content"][0]["text"]
-        assert "[REDACTED]" in redacted
-        assert redacted != assignment
+        assert redacted == assignment.replace(AWS_SECRET_VALUE, "[REDACTED]")
         assert payload.result["content"][0]["text"] == assignment
 
     @pytest.mark.parametrize("assignment", AWS_SECRET_ASSIGNMENTS)

--- a/plugins/tests/secrets_detection/test_public_rust_api.py
+++ b/plugins/tests/secrets_detection/test_public_rust_api.py
@@ -189,7 +189,7 @@ class TestPublicRustApi:
         assert isinstance(redacted, SecretBox)
         assert redacted.value == "AWS_ACCESS_KEY_ID=[REDACTED]"
         assert any(
-            value == "[REDACTED]"
+            value == "AWS_SECRET_ACCESS_KEY=[REDACTED]"
             for key, value in redacted.__dict__.items()
             if not isinstance(key, str)
         )
@@ -368,7 +368,7 @@ class TestPublicRustApi:
             {"type": "aws_access_key_id"},
             {"type": "aws_secret_access_key"},
         ]
-        assert redacted == "[REDACTED]"
+        assert redacted == "AWS_SECRET_ACCESS_KEY=[REDACTED]"
 
     def test_scan_container_redacts_non_replayable_custom_object(self):
         class NonReplayableBox:


### PR DESCRIPTION
## Summary

- redact only the detected value for `aws_secret_access_key` assignments, preserving the field name, separator, whitespace, and quotes
- apply the same value-only replacement contract to `generic_api_key_assignment`
- strengthen exact-output regression coverage for AWS assignment formats and every supported detector
- bump `secrets_detection` to 0.3.10

## Root cause

The AWS detector matched the full labeled assignment and captured the value, but the scanner only used capture-group spans for the base64 detector. Redaction therefore replaced the detector's full match, including the field name. The generic API-key assignment detector had the same whole-assignment replacement behavior and did not expose a value capture.

## Impact

An input such as:

```text
Aws Secret Access Key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
```

is now returned as:

```text
Aws Secret Access Key = "[REDACTED]"
```

instead of replacing the entire assignment.

## Validation

- `make ci` in `plugins/rust/python-package/secrets_detection`
- 96 Rust tests passed
- 114 plugin-framework integration tests passed
- formatting, Clippy with warnings denied, wheel build/install, and benchmark compilation passed

## Tracker

Addresses the follow-up reported in [WatsonOrchestrate/wo-tracker#78411](https://github.ibm.com/WatsonOrchestrate/wo-tracker/issues/78411#issuecomment-223697436).
