### PR TITLE
fix: release newly added plugins

### DIFF
--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -1737,6 +1737,43 @@ class PluginCatalogTests(unittest.TestCase):
             self.assertEqual(payload["release_validation_tags"], ["rate-limiter-v0.0.2"])
             self.assertTrue(payload["has_release_validation_tags"])
 
+    def test_ci_selection_detects_new_plugin_for_initial_release(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            git = lambda *args: subprocess.run(  # noqa: E731
+                ["git", *args],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+            git("init")
+            git("config", "user.name", "Test User")
+            git("config", "user.email", "test@example.com")
+            (root / "Cargo.toml").write_text(
+                '[workspace]\nmembers = ["plugins/rust/python-package/rate_limiter"]\n'
+            )
+            self._create_plugin(root, "rate_limiter")
+            git("add", ".")
+            git("commit", "--no-verify", "-m", "seed layout")
+            base_sha = git("rev-parse", "HEAD").stdout.strip()
+
+            (root / "Cargo.toml").write_text(
+                "[workspace]\nmembers = [\n"
+                '    "plugins/rust/python-package/rate_limiter",\n'
+                '    "plugins/rust/python-package/sql_sanitizer",\n'
+                "]\n"
+            )
+            self._create_plugin(root, "sql_sanitizer")
+            git("add", ".")
+            git("commit", "--no-verify", "-m", "add sql sanitizer")
+
+            result = run_catalog("ci-selection", str(root), "diff", base_sha, "HEAD")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["release_validation_tags"], ["sql-sanitizer-v0.0.1"])
+            self.assertTrue(payload["has_release_validation_tags"])
+
     def test_ci_selection_treats_catalog_test_change_as_not_shared(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tools/plugin_catalog.py
+++ b/tools/plugin_catalog.py
@@ -615,7 +615,10 @@ def _release_validation_tags_for_records(
         if cargo_path not in changed_paths:
             continue
         old_text = _git_file_text(root, base, cargo_path)
-        old_version = _cargo_version_from_text(old_text) if old_text is not None else None
+        if old_text is None:
+            tags.append(f"{plugin.slug.replace('_', '-')}-v{plugin.version}")
+            continue
+        old_version = _cargo_version_from_text(old_text)
         if old_version is not None and old_version != plugin.version:
             tags.append(f"{plugin.slug.replace('_', '-')}-v{plugin.version}")
     return sorted(tags)


### PR DESCRIPTION
## Summary

- Treat a newly added plugin `Cargo.toml` as an initial release candidate.
- Add regression coverage for first-time plugin additions.

## Root cause

Release tag detection only emitted a tag when the plugin had an existing base version that changed. For a new plugin, the base `Cargo.toml` does not exist, so `release_validation_tags` was empty and both release validation and tag creation were skipped.

## Impact

New plugins will now follow the same validation, automatic tagging, and release path as plugin version bumps.

## Validation

- `make plugins-validate` — 125 tests passed, 3 skipped.
- Focused initial-release and version-bump tests pass.
- Replayed the SQL sanitizer merge diff; it now emits `sql-sanitizer-v0.1.0` with `has_release_validation_tags: true`.
