### PR TITLE
pin cpex version to the current version

### DIFF
--- a/plugins/python/ica_metering_exporter/pyproject.toml
+++ b/plugins/python/ica_metering_exporter/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "ICA Team" }]
 license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["cpex>=0.1.3,<0.2", "httpx>=0.27,<1", "PyJWT>=2.8,<3"]
+dependencies = ["cpex==0.1.3", "httpx>=0.27,<1", "PyJWT>=2.8,<3"]
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/plugins/rust/python-package/encoded_exfil_detection/pyproject.toml
+++ b/plugins/rust/python-package/encoded_exfil_detection/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
     "pydantic>=2.13.4,<3",
 ]

--- a/plugins/rust/python-package/output_length_guard/pyproject.toml
+++ b/plugins/rust/python-package/output_length_guard/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
 ]
 classifiers = [

--- a/plugins/rust/python-package/pii_filter/pyproject.toml
+++ b/plugins/rust/python-package/pii_filter/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
 ]
 classifiers = [

--- a/plugins/rust/python-package/rate_limiter/pyproject.toml
+++ b/plugins/rust/python-package/rate_limiter/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
 ]
 classifiers = [

--- a/plugins/rust/python-package/retry_with_backoff/pyproject.toml
+++ b/plugins/rust/python-package/retry_with_backoff/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
     "pydantic>=2.13.4,<3",
 ]

--- a/plugins/rust/python-package/secrets_detection/pyproject.toml
+++ b/plugins/rust/python-package/secrets_detection/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
 ]
 classifiers = [

--- a/plugins/rust/python-package/sql_sanitizer/pyproject.toml
+++ b/plugins/rust/python-package/sql_sanitizer/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
 ]
 classifiers = [

--- a/plugins/rust/python-package/url_reputation/pyproject.toml
+++ b/plugins/rust/python-package/url_reputation/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "cpex>=0.1.3,<0.2",
+    "cpex==0.1.3",
     "mcp<2",
     "pydantic>=2.13.4,<3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 package = false
 exclude-newer = "10 days"
 constraint-dependencies = [
-    "cpex>=0.1.0,<0.2",
+    "cpex==0.1.3",
     "maturin>=1.13.3,<2.0",
     "mcp<2",
     "pydantic>=2.13.4,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-28T09:30:41.175368Z"
+exclude-newer = "2026-09-01T14:08:50.6713914Z"
 exclude-newer-span = "P10D"
 
 [manifest]
@@ -27,7 +27,7 @@ members = [
     "cpex-url-reputation",
 ]
 constraints = [
-    { name = "cpex", specifier = ">=0.1.0,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "maturin", specifier = ">=1.13.3,<2.0" },
     { name = "mcp", specifier = "<2" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
@@ -489,7 +489,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
 ]
@@ -522,7 +522,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "httpx", specifier = ">=0.27,<1" },
     { name = "pyjwt", specifier = ">=2.8,<3" },
 ]
@@ -552,7 +552,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
 ]
 
@@ -586,7 +586,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
 ]
 
@@ -617,7 +617,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
 ]
@@ -649,7 +649,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
 ]
 
@@ -679,7 +679,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
 ]
 
@@ -709,7 +709,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cpex", specifier = ">=0.1.3,<0.2" },
+    { name = "cpex", specifier = "==0.1.3" },
     { name = "mcp", specifier = "<2" },
     { name = "pydantic", specifier = ">=2.13.4,<3" },
 ]


### PR DESCRIPTION

Pin cpex==0.1.3 to prepare for updating the Python MCP SDK (mcp) in cpex.

related to https://github.com/IBM/mcp-context-forge/issues/6248